### PR TITLE
docs: Add document outlining token format

### DIFF
--- a/docs/token-format.md
+++ b/docs/token-format.md
@@ -8,7 +8,7 @@ We anticipate that these tokens will be used to inform further authorization dec
 
 This is as defined in [RFC 8693][rfc-8693]. At minimum, a token request includes the following parameters:
 
-- `grant_type` (always set to `urn:ietf:params:oauth:grant-type:token-exchange`
+- `grant_type` (always set to `urn:ietf:params:oauth:grant-type:token-exchange`)
 - `subject_token`
 - `subject_token_type`
 
@@ -21,22 +21,24 @@ For the first iteration of identity-manager-sts, we are only supporting the use 
 
 The token returned is an [RFC 9068][rfc-9068]-compliant access token JWT with the following claims:
 
-| claim              | description                                                                                         |
-|--------------------|-----------------------------------------------------------------------------------------------------|
-| iss                | FQDN for identity-manager-sts issuer                                                                |
-| iat                | The time the token was issued                                                                       |
-| jti                | Unique ID for the token issued                                                                      |
-| exp                | Token expiration time                                                                               |
-| sub                | Subject of the token in the infratographer namespace<br>example "sub": `infratographer:user:{uuid}` |
-| aud                | Resources on which that token may operate                                                           |
-| client_id          | ID of the client requesting the token                                                               |
-| infratographer.sub | Private claim which indicates the subject be used in policy enforcement                             |
+| claim              | description                                                                                      |
+|--------------------|--------------------------------------------------------------------------------------------------|
+| iss                | FQDN for identity-manager-sts issuer                                                             |
+| iat                | The time the token was issued                                                                    |
+| jti                | Unique ID for the token issued                                                                   |
+| exp                | Token expiration time                                                                            |
+| sub                | URN of the user in the infratographer namespace, e.g. `urn:infratographer:user/{uuid}`           |
+| aud                | Resources on which the token may operate                                                         |
+| client_id          | ID of the client requesting the token, or `null` if no client was used when requesting the token |
+| infratographer.sub | Private claim which indicates the subject be used in policy enforcement                          |
 
-The following are defined in [RFC 8693][rfc-8693], but for now aren't supported until we run into/identify the use cases for them:
+The following are defined in [RFC 8693][rfc-8693] and [RFC 9068][rfc-9068], but for now aren't supported until we run into/identify the use cases for them:
 
-- `act` describes the acting party to whom access has been delegated. identity-manager-sts currently only supports impersonation semantics, not delegation.
-- `may_act` claims in the subject_token are used together with `actor_token` to determine if the actor is authorized to proceed as the authority for the original subject.
-
+- `act`: Describes the acting party to whom access has been delegated. identity-manager-sts currently only supports impersonation semantics, not delegation.
+- `may_act`: Describes the set of claims that identify an actor that can act on behalf of the subject identified by the subject token.
+- `groups`: Describes groups that the subject is a member of in the context of the issued access token.
+- `roles`: Describes roles assigned to the subject in the context of the issued access token.
+- `entitlements`: Describes individual resources the subject can access in the context of the issued access token.
 
 ### Claim Mapping
 

--- a/docs/token-format.md
+++ b/docs/token-format.md
@@ -1,0 +1,49 @@
+# Token Format
+
+Clients can expect to exchange OAuth 2.0 access tokens for OAuth 2.0 access tokens issued by identity-manager-sts. This document outlines the parameters for token requests, how they affect the response and the meaning of the claims contained in the STS token.
+
+We anticipate that these tokens will be used to inform further AuthZ decisions later in the API Gateway stack. While we could instead exchange for ID Tokens issued by the STS, the access token gives us the ability to use standard claims to provide information necessary for AuthZ.
+
+### Token Request
+
+This is as defined in [RFC 8693]. The minimal requests includes:
+- `grant_type`
+- `subject_token`
+- `subject_token_type`
+
+STS tokens can be restricted further through the use of `audience` and `scope`. The former restricts the class of resources for which this token may be used. The latter restricts the type of actions that that token can perform on resources.
+
+As part of that RFC the requester may specify the `audience` and/or `resource`. For the first iteration of STS, we are supporting just `audience` which will allow us to expose a set of services that a user may use to restrict the context in which the token is valid. As we start to use this more, logical names may become cumbersome and being able to namespace with the URI format given by the `resource` parameter can be implemented. The `resource` parameter affects the `aud` claim on the STS token.
+
+
+### Token Response
+
+The token returned will be an OAuth 2.0 access token JWT  [RFC 9068] with the following claims:
+| claim              | description                                                                                         |
+|--------------------|-----------------------------------------------------------------------------------------------------|
+| iss                | FQDN for identity-gate-sts issuer                                                                   |
+| iat                | denotes the time the token was issued                                                               |
+| jti                | unique ID for the token issued
+| exp | date of expiry                                                                  |
+| sub                | subject of the token in the infratographer namespace<br>example "sub": `infratographer:user:{uuid}` |
+| aud                | Resource classes on which that token may operate                                                    |
+| scope              | Actions which the token is restricted to within the audiences                                       |
+| client_id | id of the client requesting the token |
+| act:sub            | original JWT subject                                             |
+| infratographer.sub | this is a private claim which indicates the subject be used in policy enforcement                   |
+
+
+The following are in the spec, but for now aren't supported until we run into/identify the use-cases for them:
+
+- `may_act` claims in the subject_token are used together with   `actor_token` to determine if the actor is authorized to proceed as the authority for the original subject.
+
+
+### Claim Mapping
+
+As an organization, I may have my own set of way of assigning permissions to users, and I want that to map the same way when operating with an exchanged token. In order to do so, a user may provide custom claim mappings.
+
+Users may provide mappings on `infratographer.sub` which build a subject based on claims in the subject token. This claim in the STS token is expected to be used in-place of the JWT "sub" claim for policy enforcement.
+
+
+[RFC 8693]:  https://www.rfc-editor.org/rfc/rfc8693.html#name-token-exchange-request-and-
+[RFC 9068]: https://www.rfc-editor.org/rfc/rfc9068.html#name-data-structure

--- a/docs/token-format.md
+++ b/docs/token-format.md
@@ -6,7 +6,7 @@ We anticipate that these tokens will be used to inform further authorization dec
 
 ### Token Request
 
-This is as defined in [RFC 8693][rfc-8693]. At minimum, an token request includes the following parameters:
+This is as defined in [RFC 8693][rfc-8693]. At minimum, a token request includes the following parameters:
 
 - `grant_type` (always set to `urn:ietf:params:oauth:grant-type:token-exchange`
 - `subject_token`
@@ -14,7 +14,7 @@ This is as defined in [RFC 8693][rfc-8693]. At minimum, an token request include
 
 Issued access tokens can be restricted further through the use of `audience`, `resource`, and `scope` parameters in the token request. `audience` and `resource` restrict the class of resources for which the issued token may be used. `scope` restricts the type of actions the token can perform on resources.
 
-For the first iteration of identity-manager-sts, we are supporting the use of `resource`, which will allow us to expose a set of services that a user may use to restrict the context in which the token is valid. The `resource` parameter maps to the `aud` claim on the issued token, as outlined in [RFC 9068][rfc-9068].
+For the first iteration of identity-manager-sts, we are only supporting the use of `resource`, which will allow us to expose a set of services that a user may use to restrict the context in which the token is valid. The `resource` parameter maps to the `aud` claim on the issued token, as outlined in [RFC 9068][rfc-9068].
 
 
 ### Token Response
@@ -29,7 +29,6 @@ The token returned is an [RFC 9068][rfc-9068]-compliant access token JWT with th
 | exp                | Token expiration time                                                                               |
 | sub                | Subject of the token in the infratographer namespace<br>example "sub": `infratographer:user:{uuid}` |
 | aud                | Resources on which that token may operate                                                           |
-| scope              | Actions which the token is restricted to within the audiences                                       |
 | client_id          | ID of the client requesting the token                                                               |
 | infratographer.sub | Private claim which indicates the subject be used in policy enforcement                             |
 


### PR DESCRIPTION
This document serves as a reference for consuming services so that the token format is well-defined, so it can be used to inform further decisions about the requesters identity.

This document also covers the request parameters and how they affect the token contained in the response.

Fixes #28 
