### PR TITLE
Enable `go mod tidy` as a postUpdateOption for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,6 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     }
-  ]
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Without this option renovate PRs leave references in `go.sum` to older dependency versions. This option is defaulted to off in renovate due to the fact that the sums may change for dependecies unrelated to the upgrade.

Since our `go.mod` has our direct dependencies pinned to a specific version, I think this is acceptable.