### PR TITLE
Bump golangci-lint run timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,10 @@ linters-settings:
   gofumpt:
     extra-rules: true
 
+run:
+  # default timeout is 1m
+  timeout: 3m
+
 linters:
   enable:
     # default linters


### PR DESCRIPTION
We were occasionally seeing `golangci-lint run` stages fail due to timing out, so changing the timeout to 3m to give the runner more time to execute.