### PR TITLE
Remove unmaintained linters and unused configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 linters-settings:
   goimports:
     local-prefixes: go.infratographer.com/identity-manager-sts
-  gofumpt:
-    extra-rules: true
 
 run:
   # default timeout is 1m
@@ -11,16 +9,13 @@ run:
 linters:
   enable:
     # default linters
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 
     # additional linters
     - bodyclose
@@ -28,7 +23,6 @@ linters:
     - gocyclo
     - goerr113
     - gofmt
-    # - gofumpt
     - goimports
     - gomnd
     - govet


### PR DESCRIPTION
The linters removed here are no longer maintained, and aren't part of the default enabled list for linters. I also removed the `gofumpt` configuration, since that wasn't an enabled linter.

![image](https://user-images.githubusercontent.com/12551067/221211463-20ab5148-47f9-4dba-be16-6d1bab283a62.png)
https://golangci-lint.run/usage/linters/