### PR TITLE
Change fositex.NewOAuth2Provider to behave like fosite Compose

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -75,9 +75,13 @@ func serve(ctx context.Context) {
 	hmacStrategy := compose.NewOAuth2HMACStrategy(oauth2Config)
 	jwtStrategy := compose.NewOAuth2JWTStrategy(keyGetter, hmacStrategy, oauth2Config)
 	store := fositestorage.NewExampleStore()
-	tokenExchangeHandler := rfc8693.NewTokenExchangeHandler(oauth2Config, jwtStrategy, store)
-	oauth2Config.TokenEndpointHandlers.Append(tokenExchangeHandler)
-	provider := fositex.NewOAuth2Provider(oauth2Config, store)
+
+	provider := fositex.NewOAuth2Provider(
+		oauth2Config,
+		store,
+		jwtStrategy,
+		rfc8693.NewTokenExchangeHandler,
+	)
 
 	apiHandler, err := httpsrv.NewAPIHandler(storageEngine)
 	if err != nil {

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -192,7 +192,7 @@ func NewOAuth2Provider(configurator *OAuth2Config, store interface{}, strategy i
 	return f
 }
 
-// Factory is a constructor which is used to create a OAuth Handler type.
+// Factory is a constructor which is used to create an OAuth2 endpoin handler.
 // NewOAuth2Provider handles consuming the new struct and attaching it
 // to the parts of the config that it implements.
 type Factory func(config OAuth2Configurator, store any, strategy any) any

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -156,21 +156,18 @@ func NewOAuth2Config(config Config) (*OAuth2Config, error) {
 	return out, nil
 }
 
-// NewOAuth2Provider creates a new fosite.OAuth2Provider given a *OAuth2Config
-// and a storage config.
-// This is slightly modified from `compose.Compose`, here we accept a
-// `*OAuth2Config` but Compose accepts a `*fosite.Config` since
-// it manipulates the config within the function. The downstream handlers
-// need the `OAuth2Config`, but we still want to register the
-// handlers in the `*fosite.Config`
-func NewOAuth2Provider(cfg *OAuth2Config, store interface{}, strategy interface{}, factories ...Factory) fosite.OAuth2Provider {
-	config := cfg.Config
+// NewOAuth2Provider creates a new fosite.OAuth2Provider given a
+// *OAuth2Config and a storage config.
+// Given a config, store, and strategy, this will use the factories to
+// create and register all endpoint handlers.
+func NewOAuth2Provider(configurator *OAuth2Config, store interface{}, strategy interface{}, factories ...Factory) fosite.OAuth2Provider {
+	config := configurator.Config
 	storage := store.(fosite.Storage)
 
 	f := fosite.NewOAuth2Provider(storage, config)
 
 	for _, factory := range factories {
-		res := factory(cfg, storage, strategy)
+		res := factory(configurator, storage, strategy)
 
 		if ah, ok := res.(fosite.AuthorizeEndpointHandler); ok {
 			config.AuthorizeEndpointHandlers.Append(ah)

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
-	"github.com/ory/fosite/compose"
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -164,7 +163,7 @@ func NewOAuth2Config(config Config) (*OAuth2Config, error) {
 // it manipulates the config within the function. The downstream handlers
 // need the `OAuth2Config`, but we still want to register the
 // handlers in the `*fosite.Config`
-func NewOAuth2Provider(cfg *OAuth2Config, store interface{}, strategy interface{}, factories ...compose.Factory) fosite.OAuth2Provider {
+func NewOAuth2Provider(cfg *OAuth2Config, store interface{}, strategy interface{}, factories ...Factory) fosite.OAuth2Provider {
 	config := cfg.Config
 	storage := store.(fosite.Storage)
 
@@ -196,3 +195,8 @@ func NewOAuth2Provider(cfg *OAuth2Config, store interface{}, strategy interface{
 
 	return f
 }
+
+// Factory is a constructor which is used to create a OAuth Handler type.
+// NewOAuth2Provider handles consuming the new struct and attaching it
+// to the parts of the config that it implements.
+type Factory func(config OAuth2Configurator, store any, strategy any) any

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -157,18 +157,18 @@ func NewOAuth2Config(config Config) (*OAuth2Config, error) {
 	return out, nil
 }
 
-// NewOAuth2Provider creates a new fosite.OAuth2Provider given an OAuth2Configurator instance
+// NewOAuth2Provider creates a new fosite.OAuth2Provider given a *OAuth2Config
 // and a storage config.
 // This is slightly modified from `compose.Compose`, here we accept a
-// `OAuth2Configurator` but Compose accepts a `*fosite.Config` since
+// `*OAuth2Config` but Compose accepts a `*fosite.Config` since
 // it manipulates the config within the function. The downstream handlers
-// need the `OAuth2Configurator`, but we still want to register the
+// need the `OAuth2Config`, but we still want to register the
 // handlers in the `*fosite.Config`
 func NewOAuth2Provider(cfg *OAuth2Config, store interface{}, strategy interface{}, factories ...compose.Factory) fosite.OAuth2Provider {
 	config := cfg.Config
-	storage := store
+	storage := store.(fosite.Storage)
 
-	f := fosite.NewOAuth2Provider(storage.(fosite.Storage), config)
+	f := fosite.NewOAuth2Provider(storage, config)
 
 	for _, factory := range factories {
 		res := factory(cfg, storage, strategy)

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -156,10 +156,9 @@ func NewOAuth2Config(config Config) (*OAuth2Config, error) {
 	return out, nil
 }
 
-// NewOAuth2Provider creates a new fosite.OAuth2Provider given a
-// *OAuth2Config and a storage config.
-// Given a config, store, and strategy, this will use the factories to
-// create and register all endpoint handlers.
+// NewOAuth2Provider creates a new fosite.OAuth2Provider.
+// The configurator, store, and strategy are all passed to the factories
+// and the resulting endpoint handlers are registered to the fosite.Config.
 func NewOAuth2Provider(configurator *OAuth2Config, store interface{}, strategy interface{}, factories ...Factory) fosite.OAuth2Provider {
 	config := configurator.Config
 	storage := store.(fosite.Storage)

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/x/errorsx"
@@ -113,12 +114,15 @@ type TokenExchangeHandler struct {
 // implement the fosite.TokenEndpointHandler interface
 var _ fosite.TokenEndpointHandler = new(TokenExchangeHandler)
 
-// NewTokenExchangeHandler creates a new TokenExchangeHandler.
-func NewTokenExchangeHandler(config fositex.OAuth2Configurator, strategy oauth2.AccessTokenStrategy, storage oauth2.AccessTokenStorage) *TokenExchangeHandler {
+// NewTokenExchangeHandler works as a compose.Factory for creating the fosite provider.
+var _ compose.Factory = NewTokenExchangeHandler
+
+// NewTokenExchangeHandler creates a new TokenExchangeHandler,
+func NewTokenExchangeHandler(config fosite.Configurator, storage any, strategy any) any {
 	return &TokenExchangeHandler{
-		accessTokenStrategy: strategy,
-		accessTokenStorage:  storage,
-		config:              config,
+		accessTokenStrategy: strategy.(oauth2.AccessTokenStrategy),
+		accessTokenStorage:  storage.(oauth2.AccessTokenStorage),
+		config:              config.(fositex.OAuth2Configurator),
 	}
 }
 

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
-	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/x/errorsx"
@@ -114,15 +113,15 @@ type TokenExchangeHandler struct {
 // implement the fosite.TokenEndpointHandler interface
 var _ fosite.TokenEndpointHandler = new(TokenExchangeHandler)
 
-// NewTokenExchangeHandler works as a compose.Factory for creating the fosite provider.
-var _ compose.Factory = NewTokenExchangeHandler
+// NewTokenExchangeHandler works as a fositex.Factory to register this handler.
+var _ fositex.Factory = NewTokenExchangeHandler
 
 // NewTokenExchangeHandler creates a new TokenExchangeHandler,
-func NewTokenExchangeHandler(config fosite.Configurator, storage any, strategy any) any {
+func NewTokenExchangeHandler(config fositex.OAuth2Configurator, storage any, strategy any) any {
 	return &TokenExchangeHandler{
 		accessTokenStrategy: strategy.(oauth2.AccessTokenStrategy),
 		accessTokenStorage:  storage.(oauth2.AccessTokenStorage),
-		config:              config.(fositex.OAuth2Configurator),
+		config:              config,
 	}
 }
 


### PR DESCRIPTION
For other oauth2 token handler types, fosite has a compose package that allows passing a config, store, and strategy to the factories for each handler. The compose function also handles attaching the resulting types to the right parts of the `fosite.Config` so that they are registered in the correct places.