### PR TITLE
Synchronize runMigrations calls behind a sync.Mutex

### DIFF
--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -3,12 +3,15 @@ package storage
 import (
 	"database/sql"
 	"embed"
+	"sync"
 
 	"github.com/pressly/goose/v3"
 )
 
 //go:embed migrations/*
 var embedMigrations embed.FS
+
+var migrationWG sync.WaitGroup
 
 func init() {
 	goose.SetBaseFS(embedMigrations)
@@ -42,10 +45,15 @@ func RunMigrations(config Config) error {
 	return runMigrations(db)
 }
 
+// runMigrations runs all embedded migrations against the given database. Subsequent calls
+// will have no effect. This function is safe to run across multiple goroutines.
 func runMigrations(db *sql.DB) error {
-	if err := goose.Up(db, "migrations"); err != nil {
-		return err
-	}
+	migrationWG.Wait()
+	migrationWG.Add(1)
 
-	return nil
+	defer migrationWG.Done()
+
+	err := goose.Up(db, "migrations")
+
+	return err
 }

--- a/internal/storage/migrate.go
+++ b/internal/storage/migrate.go
@@ -11,7 +11,7 @@ import (
 //go:embed migrations/*
 var embedMigrations embed.FS
 
-var migrationWG sync.WaitGroup
+var migrationMutex sync.Mutex
 
 func init() {
 	goose.SetBaseFS(embedMigrations)
@@ -48,10 +48,8 @@ func RunMigrations(config Config) error {
 // runMigrations runs all embedded migrations against the given database. Subsequent calls
 // will have no effect. This function is safe to run across multiple goroutines.
 func runMigrations(db *sql.DB) error {
-	migrationWG.Wait()
-	migrationWG.Add(1)
-
-	defer migrationWG.Done()
+	migrationMutex.Lock()
+	defer migrationMutex.Unlock()
 
 	err := goose.Up(db, "migrations")
 


### PR DESCRIPTION
When running tests in parallel, `goose.Up` is called for each in-memory database. This function is not safe to run across multiple goroutines and occasionally triggers the race detector during tests. To mitigate this, this PR adds a `sync.Mutex` to `runMigrations` to synchronize all calls to the function.