### PR TITLE
Add OAuthClientManager and implementation

### DIFF
--- a/internal/api/httpsrv/handler.go
+++ b/internal/api/httpsrv/handler.go
@@ -1,14 +1,11 @@
 package httpsrv
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 
 	"go.infratographer.com/identity-api/internal/storage"
-	"go.infratographer.com/identity-api/internal/types"
 	v1 "go.infratographer.com/identity-api/pkg/api/v1"
 )
 
@@ -115,131 +112,6 @@ func storageMiddleware(engine storage.Engine) gin.HandlerFunc {
 // apiHandler represents an API handler.
 type apiHandler struct {
 	engine storage.Engine
-}
-
-func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestObject) (CreateIssuerResponseObject, error) {
-	tenantID := req.TenantID
-	createOp := req.Body
-
-	var (
-		claimsMapping types.ClaimsMapping
-		err           error
-	)
-
-	if createOp.ClaimMappings != nil {
-		claimsMapping, err = types.NewClaimsMapping(*createOp.ClaimMappings)
-		if err != nil {
-			err = errorWithStatus{
-				status:  http.StatusBadRequest,
-				message: "error parsing CEL expression",
-			}
-
-			return nil, err
-		}
-	}
-
-	issuerToCreate := types.Issuer{
-		TenantID:      tenantID.String(),
-		ID:            uuid.New().String(),
-		Name:          createOp.Name,
-		URI:           createOp.URI,
-		JWKSURI:       createOp.JWKSURI,
-		ClaimMappings: claimsMapping,
-	}
-
-	issuer, err := h.engine.CreateIssuer(ctx, issuerToCreate)
-	if err != nil {
-		return nil, err
-	}
-
-	out, err := issuer.ToV1Issuer()
-	if err != nil {
-		return nil, err
-	}
-
-	return CreateIssuer200JSONResponse(out), nil
-}
-
-func (h *apiHandler) GetIssuerByID(ctx context.Context, req GetIssuerByIDRequestObject) (GetIssuerByIDResponseObject, error) {
-	id := req.Id.String()
-
-	iss, err := h.engine.GetIssuerByID(ctx, id)
-	switch err {
-	case nil:
-	case types.ErrorIssuerNotFound:
-		return nil, errorNotFound
-	default:
-		return nil, err
-	}
-
-	out, err := iss.ToV1Issuer()
-	if err != nil {
-		return nil, err
-	}
-
-	return GetIssuerByID200JSONResponse(out), nil
-}
-
-func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestObject) (UpdateIssuerResponseObject, error) {
-	id := req.Id.String()
-	updateOp := req.Body
-
-	var (
-		claimsMapping types.ClaimsMapping
-		err           error
-	)
-
-	if updateOp.ClaimMappings != nil {
-		claimsMapping, err = types.NewClaimsMapping(*updateOp.ClaimMappings)
-		if err != nil {
-			err = errorWithStatus{
-				status:  http.StatusBadRequest,
-				message: "error parsing CEL expression",
-			}
-
-			return nil, err
-		}
-	}
-
-	update := types.IssuerUpdate{
-		Name:          updateOp.Name,
-		URI:           updateOp.URI,
-		JWKSURI:       updateOp.JWKSURI,
-		ClaimMappings: claimsMapping,
-	}
-
-	issuer, err := h.engine.UpdateIssuer(ctx, id, update)
-	switch err {
-	case nil:
-	case types.ErrorIssuerNotFound:
-		return nil, errorNotFound
-	default:
-		return nil, err
-	}
-
-	out, err := issuer.ToV1Issuer()
-	if err != nil {
-		return nil, err
-	}
-
-	return UpdateIssuer200JSONResponse(out), nil
-}
-
-func (h *apiHandler) DeleteIssuer(ctx context.Context, req DeleteIssuerRequestObject) (DeleteIssuerResponseObject, error) {
-	id := req.Id.String()
-
-	err := h.engine.DeleteIssuer(ctx, id)
-	switch err {
-	case nil, types.ErrorIssuerNotFound:
-	default:
-		return nil, err
-	}
-
-	out := v1.DeleteResponse{
-		Success: true,
-	}
-
-	return DeleteIssuer200JSONResponse(out), nil
 }
 
 // APIHandler represents an identity-api management API handler.

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -1,0 +1,135 @@
+package httpsrv
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+	"go.infratographer.com/identity-api/internal/types"
+	v1 "go.infratographer.com/identity-api/pkg/api/v1"
+)
+
+func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestObject) (CreateIssuerResponseObject, error) {
+	tenantID := req.TenantID
+	createOp := req.Body
+
+	var (
+		claimsMapping types.ClaimsMapping
+		err           error
+	)
+
+	if createOp.ClaimMappings != nil {
+		claimsMapping, err = types.NewClaimsMapping(*createOp.ClaimMappings)
+		if err != nil {
+			err = errorWithStatus{
+				status:  http.StatusBadRequest,
+				message: "error parsing CEL expression",
+			}
+
+			return nil, err
+		}
+	}
+
+	issuerToCreate := types.Issuer{
+		TenantID:      tenantID.String(),
+		ID:            uuid.New().String(),
+		Name:          createOp.Name,
+		URI:           createOp.URI,
+		JWKSURI:       createOp.JWKSURI,
+		ClaimMappings: claimsMapping,
+	}
+
+	issuer, err := h.engine.CreateIssuer(ctx, issuerToCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := issuer.ToV1Issuer()
+	if err != nil {
+		return nil, err
+	}
+
+	return CreateIssuer200JSONResponse(out), nil
+}
+
+func (h *apiHandler) GetIssuerByID(ctx context.Context, req GetIssuerByIDRequestObject) (GetIssuerByIDResponseObject, error) {
+	id := req.Id.String()
+
+	iss, err := h.engine.GetIssuerByID(ctx, id)
+	switch err {
+	case nil:
+	case types.ErrorIssuerNotFound:
+		return nil, errorNotFound
+	default:
+		return nil, err
+	}
+
+	out, err := iss.ToV1Issuer()
+	if err != nil {
+		return nil, err
+	}
+
+	return GetIssuerByID200JSONResponse(out), nil
+}
+
+func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestObject) (UpdateIssuerResponseObject, error) {
+	id := req.Id.String()
+	updateOp := req.Body
+
+	var (
+		claimsMapping types.ClaimsMapping
+		err           error
+	)
+
+	if updateOp.ClaimMappings != nil {
+		claimsMapping, err = types.NewClaimsMapping(*updateOp.ClaimMappings)
+		if err != nil {
+			err = errorWithStatus{
+				status:  http.StatusBadRequest,
+				message: "error parsing CEL expression",
+			}
+
+			return nil, err
+		}
+	}
+
+	update := types.IssuerUpdate{
+		Name:          updateOp.Name,
+		URI:           updateOp.URI,
+		JWKSURI:       updateOp.JWKSURI,
+		ClaimMappings: claimsMapping,
+	}
+
+	issuer, err := h.engine.UpdateIssuer(ctx, id, update)
+	switch err {
+	case nil:
+	case types.ErrorIssuerNotFound:
+		return nil, errorNotFound
+	default:
+		return nil, err
+	}
+
+	out, err := issuer.ToV1Issuer()
+	if err != nil {
+		return nil, err
+	}
+
+	return UpdateIssuer200JSONResponse(out), nil
+}
+
+func (h *apiHandler) DeleteIssuer(ctx context.Context, req DeleteIssuerRequestObject) (DeleteIssuerResponseObject, error) {
+	id := req.Id.String()
+
+	err := h.engine.DeleteIssuer(ctx, id)
+	switch err {
+	case nil, types.ErrorIssuerNotFound:
+	default:
+		return nil, err
+	}
+
+	out := v1.DeleteResponse{
+		Success: true,
+	}
+
+	return DeleteIssuer200JSONResponse(out), nil
+}

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -1,0 +1,23 @@
+package httpsrv
+
+import (
+	"context"
+
+	v1 "go.infratographer.com/identity-api/pkg/api/v1"
+)
+
+func (h *apiHandler) DeleteOAuthClient(ctx context.Context, request DeleteOAuthClientRequestObject) (DeleteOAuthClientResponseObject, error) {
+	return DeleteOAuthClient200JSONResponse{Success: true}, nil
+}
+
+func (h *apiHandler) GetOAuthClient(ctx context.Context, request GetOAuthClientRequestObject) (GetOAuthClientResponseObject, error) {
+	var out v1.OAuthClient
+
+	return GetOAuthClient200JSONResponse(out), nil
+}
+
+func (h *apiHandler) CreateOAuthClient(ctx context.Context, reqeust CreateOAuthClientRequestObject) (CreateOAuthClientResponseObject, error) {
+	var out v1.OAuthClient
+
+	return CreateOAuthClient200JSONResponse(out), nil
+}

--- a/internal/api/httpsrv/server.gen.go
+++ b/internal/api/httpsrv/server.gen.go
@@ -17,7 +17,7 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// Delets an OAuthClient
+	// Deletes an OAuth Client
 	// (DELETE /api/v1/clients/{clientID})
 	DeleteOAuthClient(c *gin.Context, clientID openapi_types.UUID)
 	// Gets information about an OAuth 2.0 Client.
@@ -32,7 +32,7 @@ type ServerInterface interface {
 	// Updates an issuer.
 	// (PATCH /api/v1/issuers/{id})
 	UpdateIssuer(c *gin.Context, id openapi_types.UUID)
-	// Creates an oauth client.
+	// Creates an OAuth client.
 	// (POST /api/v1/tenants/{tenantID}/clients)
 	CreateOAuthClient(c *gin.Context, tenantID openapi_types.UUID)
 	// Creates an issuer.
@@ -377,7 +377,7 @@ func (response CreateIssuer200JSONResponse) VisitCreateIssuerResponse(w http.Res
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
-	// Delets an OAuthClient
+	// Deletes an OAuth Client
 	// (DELETE /api/v1/clients/{clientID})
 	DeleteOAuthClient(ctx context.Context, request DeleteOAuthClientRequestObject) (DeleteOAuthClientResponseObject, error)
 	// Gets information about an OAuth 2.0 Client.
@@ -392,7 +392,7 @@ type StrictServerInterface interface {
 	// Updates an issuer.
 	// (PATCH /api/v1/issuers/{id})
 	UpdateIssuer(ctx context.Context, request UpdateIssuerRequestObject) (UpdateIssuerResponseObject, error)
-	// Creates an oauth client.
+	// Creates an OAuth client.
 	// (POST /api/v1/tenants/{tenantID}/clients)
 	CreateOAuthClient(ctx context.Context, request CreateOAuthClientRequestObject) (CreateOAuthClientResponseObject, error)
 	// Creates an issuer.

--- a/internal/storage/crdb.go
+++ b/internal/storage/crdb.go
@@ -30,7 +30,7 @@ func newCRDBEngine(config Config) (*crdbEngine, error) {
 		return nil, err
 	}
 
-	oauthClientManager, err := newOAuthClientManager(config, db)
+	oauthClientManager, err := newOAuthClientManager(db)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/crdb.go
+++ b/internal/storage/crdb.go
@@ -10,6 +10,7 @@ import (
 type crdbEngine struct {
 	*issuerService
 	*userInfoService
+	*oauthClientManager
 	db *sql.DB
 }
 
@@ -29,10 +30,16 @@ func newCRDBEngine(config Config) (*crdbEngine, error) {
 		return nil, err
 	}
 
+	oauthClientManager, err := newOAuthClientManager(config, db)
+	if err != nil {
+		return nil, err
+	}
+
 	out := &crdbEngine{
-		issuerService:   issSvc,
-		userInfoService: userInfoSvc,
-		db:              db,
+		issuerService:      issSvc,
+		userInfoService:    userInfoSvc,
+		oauthClientManager: oauthClientManager,
+		db:                 db,
 	}
 
 	return out, nil

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -28,6 +28,7 @@ type TransactionManager interface {
 type Engine interface {
 	types.IssuerService
 	types.UserInfoService
+	types.OAuthClientManager
 	TransactionManager
 	Shutdown()
 }

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -12,6 +12,7 @@ import (
 type memoryEngine struct {
 	*issuerService
 	*userInfoService
+	*oauthClientManager
 	crdb testserver.TestServer
 	db   *sql.DB
 }
@@ -42,11 +43,17 @@ func newMemoryEngine(config Config) (*memoryEngine, error) {
 		return nil, err
 	}
 
+	oauthClientManager, err := newOAuthClientManager(config, db)
+	if err != nil {
+		return nil, err
+	}
+
 	out := &memoryEngine{
-		issuerService:   issSvc,
-		userInfoService: userInfoSvc,
-		crdb:            crdb,
-		db:              db,
+		issuerService:      issSvc,
+		userInfoService:    userInfoSvc,
+		crdb:               crdb,
+		oauthClientManager: oauthClientManager,
+		db:                 db,
 	}
 
 	err = out.seedDatabase(context.Background(), config.SeedData)

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -43,7 +43,7 @@ func newMemoryEngine(config Config) (*memoryEngine, error) {
 		return nil, err
 	}
 
-	oauthClientManager, err := newOAuthClientManager(config, db)
+	oauthClientManager, err := newOAuthClientManager(db)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/migrations/0002_oauth_client.sql
+++ b/internal/storage/migrations/0002_oauth_client.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+CREATE TABLE oauth_clients (
+    id        UUID PRIMARY KEY NOT NULL DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    name      STRING NOT NULL,
+    secret    STRING NOT NULL,
+    audience  STRING NOT NULL,
+    scope     STRING NOT NULL
+);

--- a/internal/storage/migrations/0002_oauth_client.sql
+++ b/internal/storage/migrations/0002_oauth_client.sql
@@ -4,6 +4,5 @@ CREATE TABLE oauth_clients (
     tenant_id UUID NOT NULL,
     name      STRING NOT NULL,
     secret    STRING NOT NULL,
-    audience  STRING NOT NULL,
-    scope     STRING NOT NULL
+    audience  STRING NOT NULL
 );

--- a/internal/storage/oauth_client.go
+++ b/internal/storage/oauth_client.go
@@ -55,7 +55,7 @@ func (*oauthClientManager) SetClientAssertionJWT(ctx context.Context, jti string
 	panic("unimplemented")
 }
 
-func newOAuthClientManager(config Config, db *sql.DB) (*oauthClientManager, error) {
+func newOAuthClientManager(db *sql.DB) (*oauthClientManager, error) {
 	return &oauthClientManager{
 		db: db,
 		hasher: &fosite.BCrypt{

--- a/internal/storage/oauth_client.go
+++ b/internal/storage/oauth_client.go
@@ -1,0 +1,167 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ory/fosite"
+	"go.infratographer.com/identity-api/internal/types"
+)
+
+var oauthClientCols = struct {
+	ID       string
+	TenantID string
+	Name     string
+	Secret   string
+	Audience string
+	Scope    string
+}{
+	ID:       "id",
+	TenantID: "tenant_id",
+	Name:     "name",
+	Secret:   "secret",
+	Audience: "audience",
+	Scope:    "scope",
+}
+
+var (
+	oauthClientColumns = []string{
+		oauthClientCols.TenantID,
+		oauthClientCols.Name,
+		oauthClientCols.Secret,
+		oauthClientCols.Audience,
+		oauthClientCols.Scope,
+	}
+	oauthClientColumnsStr = strings.Join(oauthClientColumns, ", ")
+)
+
+type oauthClientManager struct {
+	db     *sql.DB
+	hasher fosite.Hasher
+}
+
+// ClientAssertionJWTValid implements fosite.ClientManager
+func (*oauthClientManager) ClientAssertionJWTValid(ctx context.Context, jti string) error {
+	panic("unimplemented")
+}
+
+// GetClient implements fosite.ClientManager
+func (s *oauthClientManager) GetClient(ctx context.Context, id string) (fosite.Client, error) {
+	return s.LookupOAuthClientByID(ctx, id)
+}
+
+// SetClientAssertionJWT implements fosite.ClientManager
+func (*oauthClientManager) SetClientAssertionJWT(ctx context.Context, jti string, exp time.Time) error {
+	panic("unimplemented")
+}
+
+func newOAuthClientManager(config Config, db *sql.DB) (*oauthClientManager, error) {
+	return &oauthClientManager{
+		db: db,
+		hasher: &fosite.BCrypt{
+			Config: &fosite.Config{
+				HashCost: fosite.DefaultBCryptWorkFactor,
+			},
+		},
+	}, nil
+}
+
+// CreateOAuthClient creates an OAuth client in the database.
+func (s *oauthClientManager) CreateOAuthClient(ctx context.Context, client types.OAuthClient) (types.OAuthClient, error) {
+	var emptyModel types.OAuthClient
+
+	tx, err := getContextTx(ctx)
+	if err != nil {
+		return emptyModel, err
+	}
+
+	q := `
+        INSERT INTO oauth_clients (
+           %s
+        ) VALUES
+        ($1, $2, $3, $4, $5) RETURNING id;
+       `
+	q = fmt.Sprintf(q, oauthClientColumnsStr)
+
+	hashedSecret, err := s.hasher.Hash(ctx, []byte(client.Secret))
+	if err != nil {
+		return emptyModel, err
+	}
+
+	client.Secret = string(hashedSecret)
+
+	row := tx.QueryRowContext(
+		ctx,
+		q,
+		client.TenantID,
+		client.Name,
+		client.Secret,
+		strings.Join(client.Audience, " "),
+		client.Scope,
+	)
+
+	err = row.Scan(&client.ID)
+	if err != nil {
+		return emptyModel, err
+	}
+
+	return client, nil
+}
+
+// DeleteOAuthClient removes the OAuth client from the store.
+func (*oauthClientManager) DeleteOAuthClient(ctx context.Context, clientID string) error {
+	tx, err := getContextTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, `DELETE FROM oauth_clients WHERE id = $1;`, clientID)
+
+	return err
+}
+
+// LookupOAuthClientByID fetches an OAuth client from the store.
+func (s *oauthClientManager) LookupOAuthClientByID(ctx context.Context, clientID string) (*types.OAuthClient, error) {
+	q := fmt.Sprintf(`SELECT %s FROM oauth_clients WHERE id = $1`, oauthClientColumnsStr)
+
+	var row *sql.Row
+
+	tx, err := getContextTx(ctx)
+
+	switch err {
+	case nil:
+		row = tx.QueryRowContext(ctx, q, clientID)
+	case ErrorMissingContextTx:
+		row = s.db.QueryRowContext(ctx, q, clientID)
+	default:
+		return nil, err
+	}
+
+	var model types.OAuthClient
+
+	var aud string
+
+	err = row.Scan(
+		&model.TenantID,
+		&model.Name,
+		&model.Secret,
+		&aud,
+		&model.Scope,
+	)
+
+	switch err {
+	case nil:
+	case sql.ErrNoRows:
+		return nil, types.ErrOAuthClientNotFound
+	default:
+		return nil, err
+	}
+
+	model.ID = clientID
+	model.Audience = strings.Fields(aud)
+
+	return &model, nil
+}

--- a/internal/storage/oauth_client_test.go
+++ b/internal/storage/oauth_client_test.go
@@ -60,7 +60,7 @@ func TestOAuthClientManager(t *testing.T) {
 
 	assert.NoError(t, issSvc.seedDatabase(context.Background(), config.SeedData.Issuers))
 
-	oauthClientStore, err := newOAuthClientManager(config, db)
+	oauthClientStore, err := newOAuthClientManager(db)
 	assert.NoError(t, err)
 
 	defaultClient := types.OAuthClient{

--- a/internal/storage/oauth_client_test.go
+++ b/internal/storage/oauth_client_test.go
@@ -1,0 +1,229 @@
+package storage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-go/v2/testserver"
+	"github.com/google/uuid"
+	"github.com/ory/fosite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.infratographer.com/identity-api/internal/testingx"
+	"go.infratographer.com/identity-api/internal/types"
+)
+
+var _ types.OAuthClientManager = &oauthClientManager{}
+var _ fosite.ClientManager = &oauthClientManager{}
+
+func TestOAuthClientManager(t *testing.T) {
+	t.Parallel()
+
+	db, shutdown := testserver.NewDBForTest(t)
+
+	err := runMigrations(db)
+	if err != nil {
+		shutdown()
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		shutdown()
+	})
+
+	tenantID := "56a95c1b-33f8-4def-8b6d-ca9fe6976170"
+	issuer := types.Issuer{
+		TenantID: tenantID,
+		ID:       "e495a393-ae79-4a02-a78d-9798c7d9d252",
+		Name:     "Example",
+		URI:      "https://example.com/",
+		JWKSURI:  "https://example.com/.well-known/jwks.json",
+	}
+
+	config := Config{
+		SeedData: SeedData{
+			Issuers: []SeedIssuer{
+				{
+					TenantID: issuer.TenantID,
+					ID:       issuer.ID,
+					Name:     issuer.Name,
+					URI:      issuer.URI,
+					JWKSURI:  issuer.JWKSURI,
+				},
+			},
+		},
+	}
+
+	issSvc, err := newIssuerService(config, db)
+	assert.NoError(t, err)
+
+	assert.NoError(t, issSvc.seedDatabase(context.Background(), config.SeedData.Issuers))
+
+	oauthClientStore, err := newOAuthClientManager(config, db)
+	assert.NoError(t, err)
+
+	defaultClient := types.OAuthClient{
+		TenantID: tenantID,
+		Name:     "my-client",
+		Secret:   "foobar",
+		Audience: []string{"aud1", "aud2"},
+		Scope:    "openid profile email",
+	}
+
+	seedCtx, err := beginTxContext(context.Background(), db)
+	require.NoError(t, err)
+
+	defaultClient, err = oauthClientStore.CreateOAuthClient(seedCtx, defaultClient)
+	require.NoError(t, err)
+	require.NoError(t, commitContextTx(seedCtx))
+
+	setupWithTx := func(ctx context.Context) context.Context {
+		ctx, err := beginTxContext(ctx, db)
+		if err != nil {
+			t.Fatal("failed to start transaction")
+		}
+
+		return ctx
+	}
+
+	cleanupWithTx := func(ctx context.Context) {
+		err = rollbackContextTx(ctx)
+		if err != nil {
+			t.Fatal("failed to roll back transaction")
+		}
+	}
+
+	t.Run("LookupClientByID", func(t *testing.T) {
+		t.Parallel()
+
+		runFn := func(ctx context.Context, input string) testingx.TestResult[*types.OAuthClient] {
+			res, err := oauthClientStore.LookupOAuthClientByID(ctx, input)
+			return testingx.TestResult[*types.OAuthClient]{
+				Success: res,
+				Err:     err,
+			}
+		}
+
+		testCases := []testingx.TestCase[string, *types.OAuthClient]{
+			{
+				Name:  "NotFoundWithoutTx",
+				Input: uuid.NewString(),
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[*types.OAuthClient]) {
+					assert.Nil(t, res.Success)
+					assert.ErrorIs(t, res.Err, types.ErrOAuthClientNotFound)
+				},
+			},
+			{
+				Name:    "NotFoundWithTx",
+				Input:   uuid.NewString(),
+				SetupFn: setupWithTx,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[*types.OAuthClient]) {
+					assert.Nil(t, res.Success)
+					assert.ErrorIs(t, res.Err, types.ErrOAuthClientNotFound)
+				},
+				CleanupFn: cleanupWithTx,
+			},
+			{
+				Name:    "FoundWithTx",
+				Input:   defaultClient.ID,
+				SetupFn: setupWithTx,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[*types.OAuthClient]) {
+					assert.NoError(t, res.Err)
+					assert.Equal(t, defaultClient, *res.Success)
+					assert.NotEqual(t, "foobar", res.Success.Secret)
+				},
+				CleanupFn: cleanupWithTx,
+			},
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+
+	t.Run("CreateOAuthClient", func(t *testing.T) {
+		t.Parallel()
+
+		runFn := func(ctx context.Context, input types.OAuthClient) testingx.TestResult[types.OAuthClient] {
+			out, err := oauthClientStore.CreateOAuthClient(ctx, input)
+			return testingx.TestResult[types.OAuthClient]{
+				Success: out,
+				Err:     err,
+			}
+		}
+
+		secret := "superdupersecret"
+		testCases := []testingx.TestCase[types.OAuthClient, types.OAuthClient]{
+			{
+				Name: "Success",
+				Input: types.OAuthClient{
+					TenantID: tenantID,
+					Name:     "newclient",
+					Secret:   secret,
+					Audience: []string{"abc", "def", "ghi"},
+					Scope:    "openid profile email api",
+				},
+				SetupFn:   setupWithTx,
+				CleanupFn: cleanupWithTx,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.OAuthClient]) {
+					assert.NoError(t, res.Err)
+					client := res.Success
+					assert.NotEqual(t, secret, client.Secret)
+					assert.Equal(t, tenantID, client.TenantID)
+					assert.Equal(t, "newclient", client.Name)
+					assert.Equal(t, []string{"abc", "def", "ghi"}, client.Audience)
+					assert.Equal(t, "openid profile email api", client.Scope)
+				},
+			},
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+
+	t.Run("DeleteOAuthClient", func(t *testing.T) {
+		t.Parallel()
+
+		runFn := func(ctx context.Context, input string) testingx.TestResult[any] {
+			err := oauthClientStore.DeleteOAuthClient(ctx, input)
+			return testingx.TestResult[any]{
+				Err: err,
+			}
+		}
+
+		testCases := []testingx.TestCase[string, any]{
+			{
+				Name:      "ValidClientWithTx",
+				Input:     defaultClient.ID,
+				SetupFn:   setupWithTx,
+				CleanupFn: cleanupWithTx,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[any]) {
+					assert.NoError(t, res.Err)
+					c, err := oauthClientStore.LookupOAuthClientByID(ctx, defaultClient.ID)
+					assert.ErrorIs(t, err, types.ErrOAuthClientNotFound)
+					assert.Nil(t, c)
+				},
+			},
+			{
+				Name:  "ValidClientWithoutTx",
+				Input: defaultClient.ID,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[any]) {
+					assert.ErrorIs(t, res.Err, ErrorMissingContextTx)
+					c, err := oauthClientStore.LookupOAuthClientByID(ctx, defaultClient.ID)
+					assert.NoError(t, err)
+					assert.NotEmpty(t, c)
+				},
+			},
+
+			{
+				Name:      "NotFound",
+				Input:     uuid.NewString(),
+				SetupFn:   setupWithTx,
+				CleanupFn: cleanupWithTx,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[any]) {
+					assert.NoError(t, res.Err)
+				},
+			},
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+}

--- a/internal/storage/oauth_client_test.go
+++ b/internal/storage/oauth_client_test.go
@@ -87,7 +87,7 @@ func TestOAuthClientManager(t *testing.T) {
 	}
 
 	cleanupWithTx := func(ctx context.Context) {
-		err = rollbackContextTx(ctx)
+		err := rollbackContextTx(ctx)
 		if err != nil {
 			t.Fatal("failed to roll back transaction")
 		}

--- a/internal/types/client.go
+++ b/internal/types/client.go
@@ -1,0 +1,72 @@
+package types
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/ory/fosite"
+	v1 "go.infratographer.com/identity-api/pkg/api/v1"
+)
+
+// OAuthClient is an OAuth 2.0 Client
+type OAuthClient struct {
+	ID       string
+	TenantID string
+	Name     string
+	Secret   string
+	Audience []string
+	Scope    string
+}
+
+// GetAudience implements fosite.Client
+func (c OAuthClient) GetAudience() fosite.Arguments {
+	return fosite.Arguments(c.Audience)
+}
+
+// GetGrantTypes implements fosite.Client
+func (OAuthClient) GetGrantTypes() fosite.Arguments {
+	panic("unimplemented")
+}
+
+// GetHashedSecret implements fosite.Client
+func (c OAuthClient) GetHashedSecret() []byte {
+	return []byte(c.Secret)
+}
+
+// GetID implements fosite.Client
+func (c OAuthClient) GetID() string {
+	return c.ID
+}
+
+// GetRedirectURIs implements fosite.Client
+func (OAuthClient) GetRedirectURIs() []string {
+	panic("unimplemented")
+}
+
+// GetResponseTypes implements fosite.Client
+func (OAuthClient) GetResponseTypes() fosite.Arguments {
+	panic("unimplemented")
+}
+
+// GetScopes implements fosite.Client
+func (c OAuthClient) GetScopes() fosite.Arguments {
+	return fosite.Arguments(strings.Fields(c.Scope))
+}
+
+// IsPublic implements fosite.Client
+func (OAuthClient) IsPublic() bool {
+	return false
+}
+
+// ToV1OAuthClient converts to the OAS OAuth Client type.
+func (c OAuthClient) ToV1OAuthClient() (v1.OAuthClient, error) {
+	var client v1.OAuthClient
+
+	client.ID = uuid.MustParse(c.ID)
+	client.Name = c.Name
+	client.Secret = &c.Secret
+	client.Audience = c.Audience
+	client.Scope = c.Scope
+
+	return client, nil
+}

--- a/internal/types/client.go
+++ b/internal/types/client.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"strings"
-
 	"github.com/google/uuid"
 	"github.com/ory/fosite"
 	v1 "go.infratographer.com/identity-api/pkg/api/v1"
@@ -15,7 +13,6 @@ type OAuthClient struct {
 	Name     string
 	Secret   string
 	Audience []string
-	Scope    string
 }
 
 // GetAudience implements fosite.Client
@@ -50,7 +47,7 @@ func (OAuthClient) GetResponseTypes() fosite.Arguments {
 
 // GetScopes implements fosite.Client
 func (c OAuthClient) GetScopes() fosite.Arguments {
-	return fosite.Arguments(strings.Fields(c.Scope))
+	panic("unimplemented")
 }
 
 // IsPublic implements fosite.Client
@@ -66,7 +63,6 @@ func (c OAuthClient) ToV1OAuthClient() (v1.OAuthClient, error) {
 	client.Name = c.Name
 	client.Secret = &c.Secret
 	client.Audience = c.Audience
-	client.Scope = c.Scope
 
 	return client, nil
 }

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -16,4 +16,7 @@ var (
 	// ErrInvalidUserInfo represents an error condition where the
 	// UserInfo provided fails validation prior to storage.
 	ErrInvalidUserInfo = errors.New("failed to store user info")
+
+	// ErrOAuthClientNotFound is returned if the OAuthClient doesn't exist.
+	ErrOAuthClientNotFound = errors.New("oauth client does not exist")
 )

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -188,3 +188,10 @@ type UserInfoService interface {
 	// and unpacks it into the UserInfo type.
 	FetchUserInfoFromIssuer(ctx context.Context, iss, rawToken string) (*UserInfo, error)
 }
+
+// OAuthClientManager defines the storage interface for OAuth clients.
+type OAuthClientManager interface {
+	CreateOAuthClient(ctx context.Context, client OAuthClient) (OAuthClient, error)
+	LookupOAuthClientByID(ctx context.Context, clientID string) (*OAuthClient, error)
+	DeleteOAuthClient(ctx context.Context, clientID string) error
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -192,6 +192,6 @@ type UserInfoService interface {
 // OAuthClientManager defines the storage interface for OAuth clients.
 type OAuthClientManager interface {
 	CreateOAuthClient(ctx context.Context, client OAuthClient) (OAuthClient, error)
-	LookupOAuthClientByID(ctx context.Context, clientID string) (*OAuthClient, error)
+	LookupOAuthClientByID(ctx context.Context, clientID string) (OAuthClient, error)
 	DeleteOAuthClient(ctx context.Context, clientID string) error
 }

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.3
 info:
   title: Security Token Service Management API
-  description: Security Token Service (STS) Management API is an API for  managing STS configurations.
+  description: Security Token Service (STS) Management API is an API for managing STS configurations.
   version: 0.0.1
 
 paths:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -3,8 +3,7 @@ openapi: 3.0.3
 info:
   title: Security Token Service Management API
   description:
-    Security Token Service (STS) Management API is an API
-    for  managing STS configurations.
+    Security Token Service (STS) Management API is an API for  managing STS configurations.
   version: 0.0.1
 
 paths:
@@ -40,13 +39,13 @@ paths:
     post:
       tags:
         - OAuthClients
-      summary: Creates an oauth client.
+      summary: Creates an OAuth client.
       operationId: createOAuthClient
       parameters:
         - in: path
           name: tenantID
           required: true
-          description: OAuth client should be bound to this tenantID
+          description: Tenant to provision the OAuth client under
           schema:
             type: string
             format: uuid
@@ -89,7 +88,7 @@ paths:
     delete:
       tags:
         - OAuthClients
-      summary: Delets an OAuthClient
+      summary: Deletes an OAuth Client
       operationId: deleteOAuthClient
       parameters:
         - in: path
@@ -199,9 +198,7 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description:
-            URI for the issuer.
-            Must match the "iss" claim value in incoming JWTs
+          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string
@@ -220,9 +217,7 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description:
-            URI for the issuer.
-            Must match the "iss" claim value in incoming JWTs
+          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string
@@ -278,7 +273,6 @@ components:
         - id
         - name
         - audience
-        - scope
       properties:
         id:
           x-go-name: ID
@@ -296,6 +290,3 @@ components:
           items:
             type: string
           description: Grantable audiences
-        scope:
-          type: string
-          description: Grantable scopes

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -1,7 +1,10 @@
+---
 openapi: 3.0.3
 info:
   title: Security Token Service Management API
-  description: Security Token Service (STS) Management API is an API for managing STS configurations.
+  description:
+    Security Token Service (STS) Management API is an API
+    for  managing STS configurations.
   version: 0.0.1
 
 paths:
@@ -32,6 +35,77 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Issuer'
+
+  /api/v1/tenants/{tenantID}/clients:
+    post:
+      tags:
+        - OAuthClients
+      summary: Creates an oauth client.
+      operationId: createOAuthClient
+      parameters:
+        - in: path
+          name: tenantID
+          required: true
+          description: OAuth client should be bound to this tenantID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOAuthClient'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthClient'
+
+  /api/v1/clients/{clientID}:
+    get:
+      tags:
+        - OAuthClients
+      summary: Gets information about an OAuth 2.0 Client.
+      operationId: getOAuthClient
+      parameters:
+        - in: path
+          name: clientID
+          required: true
+          description: OAuth client ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OAuthClient'
+
+    delete:
+      tags:
+        - OAuthClients
+      summary: Delets an OAuthClient
+      operationId: deleteOAuthClient
+      parameters:
+        - in: path
+          name: clientID
+          required: true
+          description: OAuth client ID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteResponse'
 
   /api/v1/issuers/{id}:
     get:
@@ -125,7 +199,9 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
+          description:
+            URI for the issuer.
+            Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string
@@ -144,7 +220,9 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
+          description:
+            URI for the issuer.
+            Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string
@@ -174,7 +252,9 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
+          description:
+            URI for the issuer.
+            Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string
@@ -185,3 +265,37 @@ components:
           additionalProperties:
             type: string
 
+    CreateOAuthClient:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: A human-readable name for the client
+
+    OAuthClient:
+      required:
+        - id
+        - name
+        - audience
+        - scope
+      properties:
+        id:
+          x-go-name: ID
+          type: string
+          format: uuid
+          description: OAuth 2.0 Client ID
+        name:
+          type: string
+          description: Description of Client
+        secret:
+          type: string
+          description: OAuth2.0 Client Secret
+        audience:
+          type: array
+          items:
+            type: string
+          description: Grantable audiences
+        scope:
+          type: string
+          description: Grantable scopes

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -2,8 +2,7 @@
 openapi: 3.0.3
 info:
   title: Security Token Service Management API
-  description:
-    Security Token Service (STS) Management API is an API for  managing STS configurations.
+  description: Security Token Service (STS) Management API is an API for  managing STS configurations.
   version: 0.0.1
 
 paths:
@@ -247,9 +246,7 @@ components:
         uri:
           x-go-name: URI
           type: string
-          description:
-            URI for the issuer.
-            Must match the "iss" claim value in incoming JWTs
+          description: URI for the issuer. Must match the "iss" claim value in incoming JWTs
         jwks_uri:
           x-go-name: JWKSURI
           type: string

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -31,6 +31,12 @@ type CreateIssuer struct {
 	URI string `json:"uri"`
 }
 
+// CreateOAuthClient defines model for CreateOAuthClient.
+type CreateOAuthClient struct {
+	// Name A human-readable name for the client
+	Name string `json:"name"`
+}
+
 // DeleteResponse defines model for DeleteResponse.
 type DeleteResponse struct {
 	// Success Always true.
@@ -51,7 +57,8 @@ type Issuer struct {
 	// Name A human-readable name for the issuer
 	Name string `json:"name"`
 
-	// Uri URI for the issuer. Must match the "iss" claim value in incoming JWTs
+	// Uri URI for the issuer.
+	// Must match the "iss" claim value in incoming JWTs
 	URI string `json:"uri"`
 }
 
@@ -66,12 +73,34 @@ type IssuerUpdate struct {
 	// Name A human-readable name for the issuer
 	Name *string `json:"name,omitempty"`
 
-	// Uri URI for the issuer. Must match the "iss" claim value in incoming JWTs
+	// Uri URI for the issuer.
+	// Must match the "iss" claim value in incoming JWTs
 	URI *string `json:"uri,omitempty"`
+}
+
+// OAuthClient defines model for OAuthClient.
+type OAuthClient struct {
+	// Audience Grantable audiences
+	Audience []string `json:"audience"`
+
+	// Id OAuth 2.0 Client ID
+	ID openapi_types.UUID `json:"id"`
+
+	// Name Description of Client
+	Name string `json:"name"`
+
+	// Scope Grantable scopes
+	Scope string `json:"scope"`
+
+	// Secret OAuth2.0 Client Secret
+	Secret *string `json:"secret,omitempty"`
 }
 
 // UpdateIssuerJSONRequestBody defines body for UpdateIssuer for application/json ContentType.
 type UpdateIssuerJSONRequestBody = IssuerUpdate
+
+// CreateOAuthClientJSONRequestBody defines body for CreateOAuthClient for application/json ContentType.
+type CreateOAuthClientJSONRequestBody = CreateOAuthClient
 
 // CreateIssuerJSONRequestBody defines body for CreateIssuer for application/json ContentType.
 type CreateIssuerJSONRequestBody = CreateIssuer
@@ -79,20 +108,24 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xXX0/7NhT9KtbdHjYpNP2Nt7wBnVDYkBAt4gEQcpPb1pDYxr4uVFW++2Q7pX8HA+0n",
-	"UYk3N7Gvzz3n+DidQ6FqrSRKspDNwRYTrHkYnhjkhLm1Do3/rY3SaEhgeFtUXNT3NddayHF4wstSkFCS",
-	"VxdrM2mmETKwZIQcQ5NAibYwQvu5kMHJn38zfNEGrRVKWtaWZKQeUbKwjWWkmKIJmvY3JIuqaviABfmq",
-	"D8+P9t4Z4bdc3+Hs+q8+u7rMl6taLAm8HIzVgeQ1ttP8rCaB+GSzzhGbuJrLA4O85MMKmZ/GRsowmiAT",
-	"kahku9+doK4u842lHXbuLLGaUzEJj29BWHsLsWc25ZVDJiQTslC1Z+jsemDf6Sn00yRg8MkJgyVkN7G5",
-	"iGqFtbsmgR5WSHiJVitpcVtz64oCrd3BTPXMZ5aRcdhZIhoqVSGXWwAWZfyWe2MvUW63nfeYGq2LP1Km",
-	"5gQZOCfKd8TJe9++/YBvA5+7zZts+mVprStdcsLv/NpnHzTeCkKO1DaMPhbOCJqxQaC7j2YqCmS/9Qf9",
-	"39k5l3yMNUpiRxc5E5ZxGUYeeO1fehj9QZ8VSo7E2Bnuy9qQYYIq/PcN1ktDAlM0NkLqdrqdH543pVFy",
-	"LSCDw063cwgJaE6T4KmUa5FOf6SROZvORdnE5nwC+5F3YECTl5C1yZwvJNLc8BoJjYXsZncqxcreeG1N",
-	"zyBkAcLiHGXxTC0PmQ/wpP0G8CDeTrOmufOL420R2vqj2w1nS0lCSeFQaV2JIjSSPliPb75S/1eDI8jg",
-	"l3T5EZK2XyDpxmUUPLChfbxHRq5iZjktAevqmpvZK21B9paPZ0HRnGMxRcnyXtCa+wS4aRMjpscYaVuG",
-	"U6Q453iW9z6qg6+4byK0jvsU+adIq8wPZ2+wrX1obPMdw/tztncx+H8a408OLR2rcvY/k91eWM369ech",
-	"Nl9U6Ih4RevdKjfJa+wRSu53n8dB3msWSRguamV3nL21vyP/yQuxuPdCEdYuzCHkblcswHxFb6x1v0fe",
-	"iLjf90bT/BMAAP//8WoYH4oOAAA=",
+	"H4sIAAAAAAAC/+xYW2/bNhT+KwS3hw1Qbbd981saD4G6FSviBH1IgoKmji2mEsny4tQw9N+HQ0qxbMlO",
+	"421F3e1Npqhz+b7vXOA15arUSoJ0lo7X1PIcShYezw0wB6m1Hgz+1kZpME5AeMsLJsqPJdNayEU4YVkm",
+	"nFCSFe+3brqVBjqm1hkhF7RKaAaWG6HxLh3T89/+IPBFG7BWKGlJbZI49QkkCW4scYool4Opf9Oksapm",
+	"98AdWr1/+GQ/eiPQ5baHtx9+n5Lry3TzVR1LQr+8WKgXkpVQX8NbVULjya6dM5L7kskXBljGZgUQvEbm",
+	"yhCXAxERqKSbb29Q15fpzqcD8s5bR0rmeB6Ob6mw9pbGnMmSFR6IkERIrkpE6O2HK/tETiGfKqEGPnth",
+	"IKPjm5hcjKqF2l2V1Iz/eeZdfl4IkK5L+zHI8Girg0xfXBjGBApwcAlWK2mhG4P1nIO1PWEUD2xliTMe",
+	"Bht3M6UKYLLjrzGDLk9G5SLrpp1OiJpva3CuTMkcHVPvRfaERtLJj1E+t/Lb1E8AtL+Ikl3BbLR1rTPm",
+	"4P8+etJCqBJ6sDsynwmQvCfnC8OkC8k2d9CjcFD2c1sfMGPYal/dh1DIq8GIxHhIOjmq9PtZmmx+YXs5",
+	"39PEE2q50gczDhds76fADbg9mbUSm8Z7T02QdmU+UtEEeBfoE3Kuuv6mwL0RbkWuQrFMwSwFB/LL9Gr6",
+	"K3nHJFtAiXGcvU+JsITJ8ISyIyW+RRFNr6aEKzkXC28Y2rVhBglXwH4P27ZpQpdgbIxpNBgNXiJISoNk",
+	"WtAxfT0YDV7ThGrm8iCbIdNiuHw5jBPWDtfxIZ1UMUeco/iEGg0xpVlgFs/bQkaThpXgwFg6vukXGm+J",
+	"TOAxhtEAPqaNa9rmBEdxUi+VGMhhcVbVHX4c535I8NVoFJqkkq4uOKZ1IXhIZnhvMbx1y/7PBuZ0TH8a",
+	"brbaYb3SDnfWiiCHHRnEjWDuC9K6llDry5KZVQNdEMA2fI5h775pd4fY/BdR3tsEXID7z6HfTvgo6C8Q",
+	"eCxfzAGbEpsp7x6paPXBwX5CquSxZuKwsMO1yL6iWtJmKh2kKm5i0TLO2tpmL2OBgR+gUsyBSoFQKjUe",
+	"D8LFcbwQS5AknbR5ivgerpl4580qqPxZPCzC8DgtEmrFHQX+Rd2kagRmqwNoa1yTunjHffU42fu46/5r",
+	"iH/2YN0bla3+YbDrHb3a3iswxOo7JTpG3OK6n+VW23MgWVgV4kM6qZrtIayzyvbUXvd/geeMLJsrX2Rk",
+	"BmSmvMxQIC4XljQB9Ouk9fa7U0sXj28smb89TGMGQTeKbbj6usnZI6F6mD4loee0k2gc1cLDt01/EfJU",
+	"BdMu9NNoLy2ZHGwvVfVXAAAA///c8zKjSBYAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -57,8 +57,7 @@ type Issuer struct {
 	// Name A human-readable name for the issuer
 	Name string `json:"name"`
 
-	// Uri URI for the issuer.
-	// Must match the "iss" claim value in incoming JWTs
+	// Uri URI for the issuer. Must match the "iss" claim value in incoming JWTs
 	URI string `json:"uri"`
 }
 
@@ -73,8 +72,7 @@ type IssuerUpdate struct {
 	// Name A human-readable name for the issuer
 	Name *string `json:"name,omitempty"`
 
-	// Uri URI for the issuer.
-	// Must match the "iss" claim value in incoming JWTs
+	// Uri URI for the issuer. Must match the "iss" claim value in incoming JWTs
 	URI *string `json:"uri,omitempty"`
 }
 
@@ -88,9 +86,6 @@ type OAuthClient struct {
 
 	// Name Description of Client
 	Name string `json:"name"`
-
-	// Scope Grantable scopes
-	Scope string `json:"scope"`
 
 	// Secret OAuth2.0 Client Secret
 	Secret *string `json:"secret,omitempty"`
@@ -108,24 +103,24 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYW2/bNhT+KwS3hw1Qbbd981saD4G6FSviBH1IgoKmji2mEsny4tQw9N+HQ0qxbMlO",
-	"421F3e1Npqhz+b7vXOA15arUSoJ0lo7X1PIcShYezw0wB6m1Hgz+1kZpME5AeMsLJsqPJdNayEU4YVkm",
-	"nFCSFe+3brqVBjqm1hkhF7RKaAaWG6HxLh3T89/+IPBFG7BWKGlJbZI49QkkCW4scYool4Opf9Oksapm",
-	"98AdWr1/+GQ/eiPQ5baHtx9+n5Lry3TzVR1LQr+8WKgXkpVQX8NbVULjya6dM5L7kskXBljGZgUQvEbm",
-	"yhCXAxERqKSbb29Q15fpzqcD8s5bR0rmeB6Ob6mw9pbGnMmSFR6IkERIrkpE6O2HK/tETiGfKqEGPnth",
-	"IKPjm5hcjKqF2l2V1Iz/eeZdfl4IkK5L+zHI8Girg0xfXBjGBApwcAlWK2mhG4P1nIO1PWEUD2xliTMe",
-	"Bht3M6UKYLLjrzGDLk9G5SLrpp1OiJpva3CuTMkcHVPvRfaERtLJj1E+t/Lb1E8AtL+Ikl3BbLR1rTPm",
-	"4P8+etJCqBJ6sDsynwmQvCfnC8OkC8k2d9CjcFD2c1sfMGPYal/dh1DIq8GIxHhIOjmq9PtZmmx+YXs5",
-	"39PEE2q50gczDhds76fADbg9mbUSm8Z7T02QdmU+UtEEeBfoE3Kuuv6mwL0RbkWuQrFMwSwFB/LL9Gr6",
-	"K3nHJFtAiXGcvU+JsITJ8ISyIyW+RRFNr6aEKzkXC28Y2rVhBglXwH4P27ZpQpdgbIxpNBgNXiJISoNk",
-	"WtAxfT0YDV7ThGrm8iCbIdNiuHw5jBPWDtfxIZ1UMUeco/iEGg0xpVlgFs/bQkaThpXgwFg6vukXGm+J",
-	"TOAxhtEAPqaNa9rmBEdxUi+VGMhhcVbVHX4c535I8NVoFJqkkq4uOKZ1IXhIZnhvMbx1y/7PBuZ0TH8a",
-	"brbaYb3SDnfWiiCHHRnEjWDuC9K6llDry5KZVQNdEMA2fI5h775pd4fY/BdR3tsEXID7z6HfTvgo6C8Q",
-	"eCxfzAGbEpsp7x6paPXBwX5CquSxZuKwsMO1yL6iWtJmKh2kKm5i0TLO2tpmL2OBgR+gUsyBSoFQKjUe",
-	"D8LFcbwQS5AknbR5ivgerpl4580qqPxZPCzC8DgtEmrFHQX+Rd2kagRmqwNoa1yTunjHffU42fu46/5r",
-	"iH/2YN0bla3+YbDrHb3a3iswxOo7JTpG3OK6n+VW23MgWVgV4kM6qZrtIayzyvbUXvd/geeMLJsrX2Rk",
-	"BmSmvMxQIC4XljQB9Ouk9fa7U0sXj28smb89TGMGQTeKbbj6usnZI6F6mD4loee0k2gc1cLDt01/EfJU",
-	"BdMu9NNoLy2ZHGwvVfVXAAAA///c8zKjSBYAAA==",
+	"H4sIAAAAAAAC/+xXW2/bNhT+KwS3hw1QbLd981saD4G6FStiB31Ig4Kmjm2mEsny4tQw9N+HQ8qRbMn2",
+	"4l1Qb3mTaOpcvu87F68pV4VWEqSzdLimli+gYOHxygBzkFrrweC7NkqDcQLCrzxnovhcMK2FnIcTlmXC",
+	"CSVZ/mHrpltpoENqnRFyTsuEZmC5ERrv0iG9+uU3At+0AWuFkpZUJolTX0CS4MYSp4hyCzDVO002VtX0",
+	"AbhDqw+PX+xnbwS63Pbw7uOvY3J7k9ZfVbEk9NvFXF1IVkB1DW+VCY0nu3YuycIXTF4YYBmb5kDwGpkp",
+	"Q9wCiIhAJe18O4O6vUl3Pu2R9946UjDHF+H4ExXWfqIxZ7JkuQciJBGSqwIRevdxYo/kFPIpE2rgqxcG",
+	"Mjq8i8nFqBqo3ZdJxfjvl94trnIB0rVpPwUZHm21kOmKC8MYQQ4ObsBqJS20Y7Cec7C2I4z8ka0sccZD",
+	"r3Y3VSoHJlv+NmbQ5dmoXGTttNMRUbNtDc6UKZijQ+q9yI5oJB29lM8zyifg2V1Dya5eamnd6ow5eGmj",
+	"56yDMqEHeyPzmQDJO1K+Nky6kOvmDnoUDopuaqsDZgxb7av6EAp53RuQGA9JRycVfjdJo/oNm8vVnhae",
+	"UAvcgNsTXiO6cbx3bAg0q+sJz/uAvZAz1fYzBu6NcCsyCUIfg1kKDuSn8WT8M3nPJJtDgf4vP6REWMJk",
+	"eELJkAJ/RQWMJ2PClZyJuTcM7dowPoTLYb+Hbds0oUswNsY06A16rxAcpUEyLeiQvukNem9oQjVzi8B5",
+	"n2nRX77qx+Fo++v4kI7KmCOOQHxCgYWY0izQgudNFaJJwwpwYCwd3nWrhDcUIvAYw9gAPaQb17TJBU7R",
+	"pNoHMZDDyirLe/w4juyQ4OvBIDQ4JV1VLUzrXPCQTP/BYnjrhv0fDczokP7QrxfSfrWN9nc2giCHHRnE",
+	"YT7zOWlcS6j1RcHM6gm6oIAISq1php33rlncsXXPo7C3KbgG97/Dv5nwSeBfg7MECxhzwJ7Cpsq7mou6",
+	"UfT2E1ImT1UTW73tr0X2J+ol3cyUg1TFNSpaxklZ2exkLDDwH6gVc7RWKjwehYvTdC6WIEk6avIU8T1c",
+	"M/HO21VQ+bN4mIexcV4kVIo7CfxQKzXy09UBtDVuOW2847Z5mux93FT/McS/erDurcpWfzPY1YZdbm8U",
+	"GGL5nRIdI25w3c1yo+05kCwsC/EhHZWb/SFso8p21F77T/0RQUyCbZSCNmopcKcJlb81yrzMgrQ6RLKJ",
+	"7XuUShuMf1kvf3mSxgwaawx/xtjs0E81SY/p5zm9xD0JiIdvN81FyHMVTLPKz6O3NGRysLeU5R8BAAD/",
+	"/6ai6JUCFgAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
In order to have a client credentials flow, we need to be able to store and retrieve oauth clients. This PR adds the storage interface and updates the spec to have the relevant endpoints. In order to get the API types, I ran `make generate` and added stub endpoints so that the application could build.

I will add the API and credential flow implementations in a separate PR because both come with a bunch of changes and I'm trying to limit the size of this PR.