### PR TITLE
Add API endpoints for managing OAuth 2.0 clients 

### DIFF
--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -60,9 +60,6 @@ func (h *apiHandler) GetOAuthClient(ctx context.Context, request GetOAuthClientR
 
 	apiType := client.ToV1OAuthClient()
 
-	// Don't return the secret hash
-	apiType.Secret = nil
-
 	return GetOAuthClient200JSONResponse(apiType), nil
 }
 

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -2,22 +2,77 @@ package httpsrv
 
 import (
 	"context"
+	"strings"
 
-	v1 "go.infratographer.com/identity-api/pkg/api/v1"
+	"go.infratographer.com/identity-api/internal/crypto"
+	"go.infratographer.com/identity-api/internal/types"
 )
 
-func (h *apiHandler) DeleteOAuthClient(ctx context.Context, request DeleteOAuthClientRequestObject) (DeleteOAuthClientResponseObject, error) {
-	return DeleteOAuthClient200JSONResponse{Success: true}, nil
+// CreateOAuthClient creates a client for a tenant with a set name.
+// This endpoint returns the OAuth client ID and secret that the client
+// needs to provide to authenticate when requesting a token.
+func (h *apiHandler) CreateOAuthClient(ctx context.Context, request CreateOAuthClientRequestObject) (CreateOAuthClientResponseObject, error) {
+	var newClient types.OAuthClient
+	newClient.TenantID = request.TenantID.String()
+
+	if request.Body.Audience != nil {
+		newClient.Audience = *request.Body.Audience
+	}
+
+	if request.Body.Scope != nil {
+		scopes := strings.Join(*request.Body.Scope, " ")
+		newClient.Scope = scopes
+	}
+
+	secret, err := crypto.GenerateSecureToken()
+	if err != nil {
+		return nil, err
+	}
+
+	generatedSecret := string(secret)
+	newClient.Secret = generatedSecret
+
+	newClient, err = h.engine.CreateOAuthClient(ctx, newClient)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := newClient.ToV1OAuthClient()
+
+	// the object now contains the hashed secret, but the response should contain the raw secret
+	resp.Secret = &generatedSecret
+
+	return CreateOAuthClient200JSONResponse(resp), nil
 }
 
+// GetOAuthClient returns the OAuth client for that ID
 func (h *apiHandler) GetOAuthClient(ctx context.Context, request GetOAuthClientRequestObject) (GetOAuthClientResponseObject, error) {
-	var out v1.OAuthClient
+	client, err := h.engine.LookupOAuthClientByID(ctx, request.ClientID.String())
+	switch err {
+	case nil:
+	case types.ErrOAuthClientNotFound:
+		return GetOAuthClient404JSONResponse{}, err
+	default:
+		return nil, err
+	}
 
-	return GetOAuthClient200JSONResponse(out), nil
+	apiType := client.ToV1OAuthClient()
+
+	// Don't return the secret hash
+	var emptySecret string
+	apiType.Secret = &emptySecret
+
+	return GetOAuthClient200JSONResponse(apiType), nil
 }
 
-func (h *apiHandler) CreateOAuthClient(ctx context.Context, reqeust CreateOAuthClientRequestObject) (CreateOAuthClientResponseObject, error) {
-	var out v1.OAuthClient
+// DeleteOAuthClient removes the OAuth client.
+func (h *apiHandler) DeleteOAuthClient(ctx context.Context, request DeleteOAuthClientRequestObject) (DeleteOAuthClientResponseObject, error) {
+	err := h.engine.DeleteOAuthClient(ctx, request.ClientID.String())
+	switch err {
+	case nil, types.ErrOAuthClientNotFound:
+	default:
+		return nil, err
+	}
 
-	return CreateOAuthClient200JSONResponse(out), nil
+	return DeleteOAuthClient200JSONResponse{Success: true}, nil
 }

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -7,6 +7,8 @@ import (
 	"go.infratographer.com/identity-api/internal/types"
 )
 
+const defaultTokenLength = 26
+
 // CreateOAuthClient creates a client for a tenant with a set name.
 // This endpoint returns the OAuth client ID and secret that the client
 // needs to provide to authenticate when requesting a token.
@@ -18,7 +20,7 @@ func (h *apiHandler) CreateOAuthClient(ctx context.Context, request CreateOAuthC
 		newClient.Audience = *request.Body.Audience
 	}
 
-	secret, err := crypto.GenerateSecureToken()
+	secret, err := crypto.GenerateSecureToken(defaultTokenLength)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -2,6 +2,7 @@ package httpsrv
 
 import (
 	"context"
+	"net/http"
 
 	"go.infratographer.com/identity-api/internal/crypto"
 	"go.infratographer.com/identity-api/internal/types"
@@ -47,7 +48,10 @@ func (h *apiHandler) GetOAuthClient(ctx context.Context, request GetOAuthClientR
 	switch err {
 	case nil:
 	case types.ErrOAuthClientNotFound:
-		return GetOAuthClient404JSONResponse{}, err
+		return nil, errorWithStatus{
+			status:  http.StatusNotFound,
+			message: err.Error(),
+		}
 	default:
 		return nil, err
 	}

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -16,7 +16,9 @@ const defaultTokenLength = 26
 func (h *apiHandler) CreateOAuthClient(ctx context.Context, request CreateOAuthClientRequestObject) (CreateOAuthClientResponseObject, error) {
 	var newClient types.OAuthClient
 	newClient.TenantID = request.TenantID.String()
+	newClient.Name = request.Body.Name
 
+	newClient.Audience = []string{}
 	if request.Body.Audience != nil {
 		newClient.Audience = *request.Body.Audience
 	}
@@ -59,8 +61,7 @@ func (h *apiHandler) GetOAuthClient(ctx context.Context, request GetOAuthClientR
 	apiType := client.ToV1OAuthClient()
 
 	// Don't return the secret hash
-	var emptySecret string
-	apiType.Secret = &emptySecret
+	apiType.Secret = nil
 
 	return GetOAuthClient200JSONResponse(apiType), nil
 }

--- a/internal/api/httpsrv/handler_oauth_client.go
+++ b/internal/api/httpsrv/handler_oauth_client.go
@@ -2,7 +2,6 @@ package httpsrv
 
 import (
 	"context"
-	"strings"
 
 	"go.infratographer.com/identity-api/internal/crypto"
 	"go.infratographer.com/identity-api/internal/types"
@@ -17,11 +16,6 @@ func (h *apiHandler) CreateOAuthClient(ctx context.Context, request CreateOAuthC
 
 	if request.Body.Audience != nil {
 		newClient.Audience = *request.Body.Audience
-	}
-
-	if request.Body.Scope != nil {
-		scopes := strings.Join(*request.Body.Scope, " ")
-		newClient.Scope = scopes
 	}
 
 	secret, err := crypto.GenerateSecureToken()

--- a/internal/api/httpsrv/handler_test.go
+++ b/internal/api/httpsrv/handler_test.go
@@ -563,7 +563,7 @@ func TestAPIHandler(t *testing.T) {
 					assert.NoError(t, err)
 					assert.IsType(t, GetOAuthClient200JSONResponse{}, res.Success)
 					item := v1.OAuthClient(res.Success.(GetOAuthClient200JSONResponse))
-					assert.Empty(t, *item.Secret)
+					assert.Nil(t, item.Secret, "the secret field shouldn't be populated on a GET")
 					assert.Equal(t, client.ID, item.ID.String())
 					assert.Equal(t, client.Name, item.Name)
 					assert.Equal(t, client.Audience, item.Audience)

--- a/internal/api/httpsrv/handler_test.go
+++ b/internal/api/httpsrv/handler_test.go
@@ -71,7 +71,7 @@ func TestAPIHandler(t *testing.T) {
 		},
 	}
 
-	issSvc, err := storage.NewEngine(config, storage.WithMigrations(), storage.WithSeedData(seedData))
+	store, err := storage.NewEngine(config, storage.WithMigrations(), storage.WithSeedData(seedData))
 	if !assert.NoError(t, err) {
 		assert.FailNow(t, "initialization failed")
 	}
@@ -79,7 +79,7 @@ func TestAPIHandler(t *testing.T) {
 	t.Run("CreateIssuer", func(t *testing.T) {
 		t.Parallel()
 		handler := apiHandler{
-			engine: issSvc,
+			engine: store,
 		}
 
 		createOp := &v1.CreateIssuer{
@@ -90,7 +90,7 @@ func TestAPIHandler(t *testing.T) {
 		}
 
 		setupFn := func(ctx context.Context) context.Context {
-			ctx, err := issSvc.BeginContext(ctx)
+			ctx, err := store.BeginContext(ctx)
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, "setup failed")
 			}
@@ -99,7 +99,7 @@ func TestAPIHandler(t *testing.T) {
 		}
 
 		cleanupFn := func(ctx context.Context) {
-			err := issSvc.RollbackContext(ctx)
+			err := store.RollbackContext(ctx)
 			assert.NoError(t, err)
 		}
 
@@ -180,7 +180,7 @@ func TestAPIHandler(t *testing.T) {
 		t.Parallel()
 
 		handler := apiHandler{
-			engine: issSvc,
+			engine: store,
 		}
 
 		testCases := []testingx.TestCase[GetIssuerByIDRequestObject, GetIssuerByIDResponseObject]{
@@ -241,7 +241,7 @@ func TestAPIHandler(t *testing.T) {
 		t.Parallel()
 
 		handler := apiHandler{
-			engine: issSvc,
+			engine: store,
 		}
 
 		issuerID := "53dcdc2a-94e7-44d1-97f5-ce7ad136b698"
@@ -259,12 +259,12 @@ func TestAPIHandler(t *testing.T) {
 		newName := "Better issuer"
 
 		setupFn := func(ctx context.Context) context.Context {
-			ctx, err := issSvc.BeginContext(ctx)
+			ctx, err := store.BeginContext(ctx)
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, "setup failed")
 			}
 
-			_, err = issSvc.CreateIssuer(ctx, issuer)
+			_, err = store.CreateIssuer(ctx, issuer)
 			if err != nil {
 				assert.FailNow(t, "setup failed")
 			}
@@ -273,7 +273,7 @@ func TestAPIHandler(t *testing.T) {
 		}
 
 		cleanupFn := func(ctx context.Context) {
-			err := issSvc.RollbackContext(ctx)
+			err := store.RollbackContext(ctx)
 			assert.NoError(t, err)
 		}
 
@@ -345,7 +345,7 @@ func TestAPIHandler(t *testing.T) {
 		t.Parallel()
 
 		handler := apiHandler{
-			engine: issSvc,
+			engine: store,
 		}
 
 		issuerID := "c8d6458e-2524-4cf9-9e8d-a3f94b114b74"
@@ -361,12 +361,12 @@ func TestAPIHandler(t *testing.T) {
 		}
 
 		setupFn := func(ctx context.Context) context.Context {
-			ctx, err := issSvc.BeginContext(ctx)
+			ctx, err := store.BeginContext(ctx)
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, "setup failed")
 			}
 
-			_, err = issSvc.CreateIssuer(ctx, issuer)
+			_, err = store.CreateIssuer(ctx, issuer)
 
 			if !assert.NoError(t, err) {
 				assert.FailNow(t, "error initializing issuer")
@@ -376,7 +376,7 @@ func TestAPIHandler(t *testing.T) {
 		}
 
 		cleanupFn := func(ctx context.Context) {
-			err := issSvc.RollbackContext(ctx)
+			err := store.RollbackContext(ctx)
 			assert.NoError(t, err)
 		}
 
@@ -405,7 +405,7 @@ func TestAPIHandler(t *testing.T) {
 
 					assert.Equal(t, expResp, obsResp)
 
-					_, err := issSvc.GetIssuerByID(ctx, issuerID)
+					_, err := store.GetIssuerByID(ctx, issuerID)
 					assert.ErrorIs(t, err, types.ErrorIssuerNotFound)
 				},
 				CleanupFn: cleanupFn,
@@ -451,4 +451,259 @@ func TestAPIHandler(t *testing.T) {
 
 		testingx.RunTests(context.Background(), t, testCases, runFn)
 	})
+
+	t.Run("CreateOAuthClient", func(t *testing.T) {
+		t.Parallel()
+
+		handler := apiHandler{
+			engine: store,
+		}
+
+		setupFn := func(ctx context.Context) context.Context {
+			ctx, err := store.BeginContext(ctx)
+			if !assert.NoError(t, err) {
+				assert.FailNow(t, "setup failed")
+			}
+
+			return ctx
+		}
+
+		cleanupFn := func(ctx context.Context) {
+			err := store.RollbackContext(ctx)
+			assert.NoError(t, err)
+		}
+
+		runFn := func(ctx context.Context, input CreateOAuthClientRequestObject) testingx.TestResult[CreateOAuthClientResponseObject] {
+			resp, err := handler.CreateOAuthClient(ctx, input)
+
+			result := testingx.TestResult[CreateOAuthClientResponseObject]{
+				Success: resp,
+				Err:     err,
+			}
+
+			return result
+		}
+
+		testCases := []testingx.TestCase[CreateOAuthClientRequestObject, CreateOAuthClientResponseObject]{
+			{
+				Name: "Success",
+				Input: CreateOAuthClientRequestObject{
+					TenantID: uuid.New(),
+					Body: &v1.CreateOAuthClientJSONRequestBody{
+						Name:     "test-client",
+						Audience: &[]string{"aud1", "aud2"},
+					},
+				},
+				SetupFn: setupFn,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[CreateOAuthClientResponseObject]) {
+					assert.NoError(t, res.Err)
+					assert.IsType(t, CreateOAuthClient200JSONResponse{}, res.Success)
+					resp := v1.OAuthClient(res.Success.(CreateOAuthClient200JSONResponse))
+					assert.NotEmpty(t, resp.ID)
+					assert.NotEmpty(t, *resp.Secret)
+					assert.Equal(t, []string{"aud1", "aud2"}, resp.Audience)
+				},
+				CleanupFn: cleanupFn,
+			},
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+
+	t.Run("GetOAuthClient", func(t *testing.T) {
+		t.Parallel()
+
+		handler := apiHandler{
+			engine: store,
+		}
+		client := types.OAuthClient{
+			TenantID: tenantID,
+			Name:     "Example",
+			Secret:   "abc1234",
+			Audience: []string{},
+		}
+
+		withStoredClients(t, store, &client)
+
+		setupFn := func(ctx context.Context) context.Context {
+			ctx, err := store.BeginContext(ctx)
+			if !assert.NoError(t, err) {
+				assert.FailNow(t, "setup failed")
+			}
+
+			return ctx
+		}
+
+		cleanupFn := func(ctx context.Context) {
+			err := store.RollbackContext(ctx)
+			assert.NoError(t, err)
+		}
+
+		testCases := []testingx.TestCase[GetOAuthClientRequestObject, GetOAuthClientResponseObject]{
+			{
+				Name: "NotFound",
+				Input: GetOAuthClientRequestObject{
+					ClientID: uuid.Nil,
+				},
+				SetupFn:   setupFn,
+				CleanupFn: cleanupFn,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[GetOAuthClientResponseObject]) {
+					assert.IsType(t, errorWithStatus{}, res.Err)
+					assert.Equal(t, http.StatusNotFound, res.Err.(errorWithStatus).status)
+				},
+			},
+			{
+				Name: "Success",
+				Input: GetOAuthClientRequestObject{
+					ClientID: uuid.MustParse(client.ID),
+				},
+				SetupFn:   setupFn,
+				CleanupFn: cleanupFn,
+				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[GetOAuthClientResponseObject]) {
+					assert.NoError(t, err)
+					assert.IsType(t, GetOAuthClient200JSONResponse{}, res.Success)
+					item := v1.OAuthClient(res.Success.(GetOAuthClient200JSONResponse))
+					assert.Empty(t, *item.Secret)
+					assert.Equal(t, client.ID, item.ID.String())
+					assert.Equal(t, client.Name, item.Name)
+					assert.Equal(t, client.Audience, item.Audience)
+				},
+			},
+		}
+
+		runFn := func(ctx context.Context, input GetOAuthClientRequestObject) testingx.TestResult[GetOAuthClientResponseObject] {
+			resp, err := handler.GetOAuthClient(ctx, input)
+
+			result := testingx.TestResult[GetOAuthClientResponseObject]{
+				Success: resp,
+				Err:     err,
+			}
+
+			return result
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+
+	t.Run("DeleteOAuthClient", func(t *testing.T) {
+		t.Parallel()
+
+		handler := apiHandler{
+			engine: store,
+		}
+
+		client := types.OAuthClient{
+			TenantID: tenantID,
+			Name:     "Example",
+			Secret:   "abc1234",
+			Audience: []string{},
+		}
+
+		withStoredClients(t, store, &client)
+
+		setupFn := func(ctx context.Context) context.Context {
+			ctx, err := store.BeginContext(ctx)
+			if !assert.NoError(t, err) {
+				assert.FailNow(t, "setup failed")
+			}
+
+			return ctx
+		}
+
+		cleanupFn := func(ctx context.Context) {
+			err := store.RollbackContext(ctx)
+			assert.NoError(t, err)
+		}
+
+		testCases := []testingx.TestCase[DeleteOAuthClientRequestObject, DeleteOAuthClientResponseObject]{
+			{
+				Name: "Success",
+				Input: DeleteOAuthClientRequestObject{
+					ClientID: uuid.MustParse(client.ID),
+				},
+				SetupFn: setupFn,
+				CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[DeleteOAuthClientResponseObject]) {
+					if !assert.NoError(t, result.Err) {
+						return
+					}
+
+					resp, ok := result.Success.(DeleteOAuthClient200JSONResponse)
+					if !ok {
+						assert.FailNow(t, "unexpected result type for delete issuer response")
+					}
+
+					obsResp := v1.DeleteResponse(resp)
+
+					expResp := v1.DeleteResponse{
+						Success: true,
+					}
+
+					assert.Equal(t, expResp, obsResp)
+
+					_, err := store.LookupOAuthClientByID(ctx, client.ID)
+					assert.ErrorIs(t, types.ErrOAuthClientNotFound, err)
+				},
+				CleanupFn: cleanupFn,
+			},
+			{
+				Name: "NotFound",
+				Input: DeleteOAuthClientRequestObject{
+					ClientID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+				},
+				SetupFn: setupFn,
+				CheckFn: func(ctx context.Context, t *testing.T, result testingx.TestResult[DeleteOAuthClientResponseObject]) {
+					if !assert.NoError(t, result.Err) {
+						return
+					}
+
+					resp, ok := result.Success.(DeleteOAuthClient200JSONResponse)
+					if !ok {
+						assert.FailNow(t, "unexpected result type for delete issuer response")
+					}
+
+					obsResp := v1.DeleteResponse(resp)
+
+					expResp := v1.DeleteResponse{
+						Success: true,
+					}
+
+					assert.Equal(t, expResp, obsResp)
+				},
+				CleanupFn: cleanupFn,
+			},
+		}
+
+		runFn := func(ctx context.Context, input DeleteOAuthClientRequestObject) testingx.TestResult[DeleteOAuthClientResponseObject] {
+			resp, err := handler.DeleteOAuthClient(ctx, input)
+
+			result := testingx.TestResult[DeleteOAuthClientResponseObject]{
+				Success: resp,
+				Err:     err,
+			}
+
+			return result
+		}
+
+		testingx.RunTests(context.Background(), t, testCases, runFn)
+	})
+}
+
+func withStoredClients(t *testing.T, s storage.Engine, clients ...*types.OAuthClient) {
+	seedCtx, err := s.BeginContext(context.Background())
+	if err != nil {
+		assert.FailNow(t, "failed to begin context")
+	}
+
+	for _, c := range clients {
+		client := c
+		*client, err = s.CreateOAuthClient(seedCtx, *client)
+
+		if !assert.NoError(t, err) {
+			assert.FailNow(t, "error initializing oauth client")
+		}
+	}
+
+	if err := s.CommitContext(seedCtx); err != nil {
+		assert.FailNow(t, "error committing seed clients")
+	}
 }

--- a/internal/api/httpsrv/server.gen.go
+++ b/internal/api/httpsrv/server.gen.go
@@ -253,6 +253,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/api/v1/tenants/:tenantID/issuers", wrapper.CreateIssuer)
 }
 
+type NotFoundJSONResponse Error
+
 type DeleteOAuthClientRequestObject struct {
 	ClientID openapi_types.UUID `json:"clientID"`
 }
@@ -283,6 +285,15 @@ type GetOAuthClient200JSONResponse OAuthClient
 func (response GetOAuthClient200JSONResponse) VisitGetOAuthClientResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetOAuthClient404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetOAuthClient404JSONResponse) VisitGetOAuthClientResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/internal/api/httpsrv/server.gen.go
+++ b/internal/api/httpsrv/server.gen.go
@@ -253,8 +253,6 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/api/v1/tenants/:tenantID/issuers", wrapper.CreateIssuer)
 }
 
-type NotFoundJSONResponse Error
-
 type DeleteOAuthClientRequestObject struct {
 	ClientID openapi_types.UUID `json:"clientID"`
 }
@@ -285,15 +283,6 @@ type GetOAuthClient200JSONResponse OAuthClient
 func (response GetOAuthClient200JSONResponse) VisitGetOAuthClientResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
-type GetOAuthClient404JSONResponse struct{ NotFoundJSONResponse }
-
-func (response GetOAuthClient404JSONResponse) VisitGetOAuthClientResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(404)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/internal/crypto/generator.go
+++ b/internal/crypto/generator.go
@@ -1,0 +1,26 @@
+// Package crypto provides tools to generate random tokens
+package crypto
+
+import (
+	"crypto/md5"
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// SecureToken is a randomly generated token.
+type SecureToken string
+
+// GenerateSecureToken creates a cryptographically random SecureToken.
+func GenerateSecureToken() (SecureToken, error) {
+	randomData := make([]byte, md5.Size)
+
+	_, err := rand.Read(randomData)
+	if err != nil {
+		return SecureToken(""), err
+	}
+
+	hasher := md5.New()
+	output := hasher.Sum(randomData)
+
+	return SecureToken(hex.EncodeToString(output)), nil
+}

--- a/internal/crypto/generator.go
+++ b/internal/crypto/generator.go
@@ -2,25 +2,20 @@
 package crypto
 
 import (
-	"crypto/md5"
-	"crypto/rand"
-	"encoding/hex"
+	"github.com/ory/x/randx"
 )
+
+var secretCharSet = randx.AlphaNum
 
 // SecureToken is a randomly generated token.
 type SecureToken string
 
 // GenerateSecureToken creates a cryptographically random SecureToken.
-func GenerateSecureToken() (SecureToken, error) {
-	randomData := make([]byte, md5.Size)
-
-	_, err := rand.Read(randomData)
+func GenerateSecureToken(length int) (SecureToken, error) {
+	secret, err := randx.RuneSequence(length, secretCharSet)
 	if err != nil {
 		return SecureToken(""), err
 	}
 
-	hasher := md5.New()
-	output := hasher.Sum(randomData)
-
-	return SecureToken(hex.EncodeToString(output)), nil
+	return SecureToken(secret), nil
 }

--- a/internal/types/client.go
+++ b/internal/types/client.go
@@ -61,7 +61,6 @@ func (c OAuthClient) ToV1OAuthClient() v1.OAuthClient {
 
 	client.ID = uuid.MustParse(c.ID)
 	client.Name = c.Name
-	client.Secret = &c.Secret
 	client.Audience = c.Audience
 
 	return client

--- a/internal/types/client.go
+++ b/internal/types/client.go
@@ -56,7 +56,7 @@ func (OAuthClient) IsPublic() bool {
 }
 
 // ToV1OAuthClient converts to the OAS OAuth Client type.
-func (c OAuthClient) ToV1OAuthClient() (v1.OAuthClient, error) {
+func (c OAuthClient) ToV1OAuthClient() v1.OAuthClient {
 	var client v1.OAuthClient
 
 	client.ID = uuid.MustParse(c.ID)
@@ -64,5 +64,5 @@ func (c OAuthClient) ToV1OAuthClient() (v1.OAuthClient, error) {
 	client.Secret = &c.Secret
 	client.Audience = c.Audience
 
-	return client, nil
+	return client
 }

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -288,11 +288,6 @@ components:
           type: array
           items:
             type: string
-        scope:
-          description: Scopes that this client can request
-          type: array
-          items:
-            type: string
 
     OAuthClient:
       required:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -83,8 +83,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OAuthClient'
-        '404':
-          $ref: '#/components/responses/NotFound'
     delete:
       tags:
         - OAuthClients
@@ -177,13 +175,6 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
 
 components:
-  responses:
-    NotFound:
-      description: Resource was not found
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/Error"
   schemas:
     Error:
       type: object

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -176,17 +176,6 @@ paths:
 
 components:
   schemas:
-    Error:
-      type: object
-      required:
-        - errors
-      properties:
-        errors:
-          description: List of error messages
-          type: array
-          items:
-            type: string
-
     DeleteResponse:
       required:
         - success

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -83,7 +83,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/OAuthClient'
-
+        '404':
+          $ref: '#/components/responses/NotFound'
     delete:
       tags:
         - OAuthClients
@@ -176,7 +177,25 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
 
 components:
+  responses:
+    NotFound:
+      description: Resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
   schemas:
+    Error:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          description: List of error messages
+          type: array
+          items:
+            type: string
+
     DeleteResponse:
       required:
         - success
@@ -264,6 +283,16 @@ components:
         name:
           type: string
           description: A human-readable name for the client
+        audience:
+          description: Audiences that this client can request
+          type: array
+          items:
+            type: string
+        scope:
+          description: Scopes that this client can request
+          type: array
+          items:
+            type: string
 
     OAuthClient:
       required:

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -38,9 +38,6 @@ type CreateOAuthClient struct {
 
 	// Name A human-readable name for the client
 	Name string `json:"name"`
-
-	// Scope Scopes that this client can request
-	Scope *[]string `json:"scope,omitempty"`
 }
 
 // DeleteResponse defines model for DeleteResponse.
@@ -118,26 +115,25 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYW2/bNhT+KwS3hw1Qbffy5Lc07gJ17VbECfqQBgVDHdtMJVLjIZ0agf77cEjZliLF",
-	"aYxsqLe+URR1Lt/5zoW65dIUpdGgHfLxLbeApdEI4eEP434zXme0lkY70I6WoixzJYVTRg+v0WjaQ7mA",
-	"QtDqZwszPuY/DbeCh/EtDt9YayyvqirhGaC0qiQhfMxPAY23EtiNQKaNY7Oglw7W35LoYwvCQYrowdJz",
-	"aU0J1qlorcyFKj4XoiyVnocdkWWKFIj8Q+ukW5XAxxydVXrOO8Ycv3nH4GtpAVEZjawWyZz5ApoFNcic",
-	"YcYtwNbPPFlLNVfXIB1Jvb75gp+9VaSyreHtx9+n7Pw03X5V25Lwr8/m5pkWBdTH6FSV8LhzV84RW/hC",
-	"6GcWRCaucmB0jM2MZW4BTEWgkq6/vUadn6Z3Ph2w9x4dK4STi7D9iSvETzz6zJYi98CUZkpLUxBCbz+e",
-	"4QM+BX+qhFv4yysLGR9fROeiVQ3ULqukjvifR94tjnNV868dduEzBVr2oVO/QeYWwjG3UMhkkMKk0Iws",
-	"AHQ84cpB0U+MekNYK1b7hiGq7AsDSlP2iJvS9pMZ3Yc1QTuBHByc1vnexRW9lIDY421+I1bInPUw2Hp1",
-	"ZUwOQnf0rcWQypj+HU1A2z2K3il0zMxYeM8KQBRzwP1dr/Vc9qTqwdQUlXVxSieEUivjZ8YWwvEx915l",
-	"D2RkOvlRrB5RrAKe/RUrucuXyw21zstMOPjRtA6ZB1XC9+xEJ1ZoF3xdn8FHtZ2+rA+msBeDEYv2sHSy",
-	"V+L3B2myfaLicnx/DwNpwd1jXsO6aTzXkbAjuzZ4XgbslZ6ZnmYJ0lvlVuwsEH0KdqkksF+mZ9Nf2Xuh",
-	"xRwK0n/0IWUKmdBhRZQp6CURYHo2ZdLomZp7G6ZaDH1NuRzuV9AWzRO+BIvRpNFgNHhO2JgStCgVH/OX",
-	"g9HgJU94KdwihHwoSjVcPh/G1o7D27hIJ1V0kXozrYhfwaY0C1Gh/SYJSaQVBTigDnrRTxLZIIiibTJj",
-	"jfOYr1XzZiiovSeNsX43sarqMmnfHV6MRk92bbgzqvTcH6Zxypj5nDWOJRx9UQi72kAXCBBB2VJaUOG9",
-	"aOZ2rNzzyOt2CE7A/e/wbzr8reAn/NXo1X2CN5YON1fMdrROwCGjhCenqQaJK+PdNnjbwjK4P4JVskmz",
-	"2BpweKuyb0iwdN2DdsY2jl1RMnXWWmZviEPI/gPJZR9MrhqPG+Vi952rJWiWTppxivjuTrJ45vUqpMWj",
-	"4jAPbeawglAzbi/wQ65skb9a7UC7pKmoi3ecTvejvY+T7T+GeLjvvjbZ6onBrifyqj2BkInVdxroaHEj",
-	"1v1RbpQ9B1qE6SIu0km1HjjC9GqwJ/e6v1weIMRZkE1UKK1ZKhqCQua3ep/XWaBWD0nWtn2PVOmC8S/z",
-	"ZZ/W2yJN9KAx98hHtM0e/tSd9CH+PKaWuA2BZPh2XVyUPlTCNLP8MGpLgyY7a0tV/R0AAP//YhK7rDIY",
-	"AAA=",
+	"H4sIAAAAAAAC/+xY32/bNhD+VwhuDxug2O6PJ7+lcReoa7ciTtCHNCgY6mwzlUiNRzo1Av3vw5GyLUVK",
+	"XBvd0Gx9oyjq7vjd992dfcelKUqjQTvk4ztuAUujEcLDH8b9ZrzOaC2NdqAdLUVZ5koKp4we3qDRtIdy",
+	"AYWg1c8WZnzMfxpuDQ/jWxy+ttZYXlVVwjNAaVVJRviYnwEabyWwW4FMG8dmwS8drL8l0ycWhIMU0YOl",
+	"59KaEqxTMVqZC1V8KkRZKj0POyLLFDkQ+fvWSbcqgY85Oqv0nHeCOXn9lsGX0gKiMhpZbZI58xk0C26Q",
+	"OcOMW4Ctn3mytmqub0A6snpz+xk/eavIZdvDmw+/T9nFWbr9qo4l4V+O5uZIiwLqY3SqSnjcuW/nmC18",
+	"IfSRBZGJ6xwYHWMzY5lbAFMRqKR7396gLs7Se58O2DuPjhXCyUXY/sgV4kce78yWIvfAlGZKS1MQQm8+",
+	"nOOOO4X7VAm38JdXFjI+voyXi1E1ULuqkjrjfx57tzjJVc2/dtqFzxRo2YdO/QaZWwjH3EIhk8EKk0Iz",
+	"igDQ8YQrB0U/MeoNYa1YHZqG6LKbhj4Q6M4TyMHBWS3E7oXRSwmIPWHkt2KFzFkPg627a2NyELrjb22G",
+	"XEZddjwBbfc4eqvQMTNj4T0rAFHMAfcA8l4otZ+rHg09GbGrrItTOiGUWlKcGVsIx8fce5XtkEo6+VFF",
+	"9qgiAc/+UpLc58vVhloXZSYc/OgmT5kHVcIPbBGnVmgX7ro+g3v1gz7Vh1DY88GIxXhYOjlI+P1Jmmyf",
+	"qLicPNBcEo4gLbgHwmtEN43ndrWnpro2eF4F7JWema6fKUhvlVux80D0KdilksB+mZ5Pf2XvhBZzKMj/",
+	"8fuUKWRChxVRpqCXRIDp+ZRJo2dq7m0YNzH0NeVyeNhB2zRP+BIsxpBGg9HgGWFjStCiVHzMXwxGgxc8",
+	"4aVwi5DyoSjVcPlsGLs2Du/iIp1U8YrUm2lF/AoxpVnICu03SUgmrSjAAXXQy36SyAZBFG1TGGucx3zt",
+	"mjdTQe09aczbjxOrqq6S9lD/fDT6ZvP8vVGlZ7Cfxilj5nPWOJZw9EUh7GoDXSBABGVLaUGF97Kp7Vi5",
+	"55HX7RScgvvf4d+88NeCn/CXo5cPGd5EOtz89mtn6xQcMhI8XZpqkLg23m2Tty0sg4czWCUbmcXWgMM7",
+	"lX2FwNJ1D3o0t3Hsipaps9Y2e1McUvYfEJfdKa4aj1vlYvedqyVolk6aeYr4Pi6yeObVKshirzzMQ5t5",
+	"WkmoGXcQ+EErW+SvV4+gXdJU1MU7TqeH0d7HyfYfQzz8en5lstU3BrueyKv2BEIhVt9pomPEjVz3Z7lR",
+	"9hxoEaaLuEgn1XrgCNOrwR7tdf8L2UGI82CbqFBas1Q0BAXlt3qf11mgVg9J1rF9j1TpgvEv8+WQ1tsi",
+	"TbxBY+6Re7TNHv7UnXQXf/apJW5DIBm+XRcXpZ8qYZoqfxq1pUGTR2tLVf0dAAD//3k5DefLFwAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -99,9 +99,6 @@ type OAuthClient struct {
 	// Name Description of Client
 	Name string `json:"name"`
 
-	// Scope Grantable scopes
-	Scope string `json:"scope"`
-
 	// Secret OAuth2.0 Client Secret
 	Secret *string `json:"secret,omitempty"`
 }
@@ -121,26 +118,26 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xY3W/bNhD/Vw7cHjZAtd2PJ7+1cReoa7ciTtCHNCho6mwzlUiNRyU1Av3vw5GyLceK",
-	"ExvZ0Gx9oyjqPn73uw/qRihblNag8SSGN8IhldYQhoc/rP/NVibjtbLGo/G8lGWZayW9tqZ/SdbwHqk5",
-	"FpJXPzuciqH4qb8W3I9vqf/WOetEXdeJyJCU0yULEUNxgmQrpxCuJYGxHqZBLx9svmXRRw6lx5SoQsfP",
-	"pbMlOq+jtSqXuvhSyLLUZhZ2ZJZpViDzjxsn/aJEMRTknTYzsWXM0dv3gN9Kh0TaGoJGJHj7FQ0ENQTe",
-	"gvVzdM2zSJZS7eQSlWepl9df6UvlNKvc1PDu0+9jODtJ1181tiTi27OZfWZkgc0xPlUnIu7clvMa5lUh",
-	"zTOHMpOTHIGPwdQ68HMEHYFKtv3tNOrsJL31aQ8+VOShkF7Nw/ZnoYk+i+gzXMm8QtAGtFG2YITefTql",
-	"e3wK/tSJcPhXpR1mYngenYtWtVC7qJMm4n++rvz8KNcN/zbDLqtMo1Fd6DRvCPxcevBzTaCCFFDSAFuA",
-	"5EUitMeimxjNhnROLg4NQ1TZFQZStuwQN+btRzO6C2uGdoQ5ejxp8n0bV6qUQqIOb/NruSDwrsLe2quJ",
-	"tTlKs6VvKYZVxvTf0oS83aHovSYPdgrhPRRIJGdIh7ve6LnoSNUnU1N0to1TOmKUNjJ+al0hvRiKqtLZ",
-	"PRmZjn4Uqz2KVcCzu2Ilt/lysaLWWZlJjz+a1lPmQZ2IAzvRsZPGB1+XZ2ivttOV9cEUeNEbQLQH0tFB",
-	"id8dpNH6iYvL0b49bO1xOECdn6Jy6O/wrOXYOJ7bkrAjMVehWBp4EcKnzdR29FtUldN+AachV8borrRC",
-	"+GV8Ov4VPkgjZ1iwHa8/pqAJpAkrZh0U/JZJND4dg7JmqmeVC5Mxhd6ofY53a9iULRJxhY6iTYPeoPec",
-	"QbIlGllqMRQve4PeS5GIUvp5oE1flrp/9bwfxwPq38RFOqqjj9zfecUcDTalWYgs77eJzCKdLNAjd+Hz",
-	"bqKpFsk0b7MZS8CHYqlatGPCI0LSuhrsJmddXySb948Xg8GjXT1ujTsdd5BxnFSmVQ6tY4mgqiikWyyh",
-	"CwTYhM9LLt3n7eoQa/8s0nszAMfo/3fotx1+KPSJeDV4dZfglaX91SV1M1bHHCnOd3aaq5ic2MqvYtcq",
-	"nL27I1gnqySLzYX6Nzp7QHqlyy62M7ZxcIuSuTc3MjtDHEL2H0gttyO1MORWg8e19rF/z/QVGkhH7ThF",
-	"fHcnWTzzZhHSYq84zEK3eVpBaBh3EPjHTVVrEJgsdqBd8ly1jXecbw+jfRVn438M8XBjfmOzxSOD3cz0",
-	"9eYgwibW32mgo8WtWHdHuVX2PBoZZou4SEf1ctwI86+ljtzb/mmzT4+jua3yDCYIEy7rTJDwE2RpQDdP",
-	"Wm+/O7Zs4/EvU+aQ7rvBm+hB4I2V61g9rHN2UKhppvdRaJ9yEoUzW1T4dllftHmqhGkn+tMoLy2a7Cwv",
-	"df13AAAA///CDzWIdxgAAA==",
+	"H4sIAAAAAAAC/+xYW2/bNhT+KwS3hw1Qbffy5Lc07gJ17VbECfqQBgVDHdtMJVLjIZ0agf77cEjZliLF",
+	"aYxsqLe+URR1Lt/5zoW65dIUpdGgHfLxLbeApdEI4eEP434zXme0lkY70I6WoixzJYVTRg+v0WjaQ7mA",
+	"QtDqZwszPuY/DbeCh/EtDt9YayyvqirhGaC0qiQhfMxPAY23EtiNQKaNY7Oglw7W35LoYwvCQYrowdJz",
+	"aU0J1qlorcyFKj4XoiyVnocdkWWKFIj8Q+ukW5XAxxydVXrOO8Ycv3nH4GtpAVEZjawWyZz5ApoFNcic",
+	"YcYtwNbPPFlLNVfXIB1Jvb75gp+9VaSyreHtx9+n7Pw03X5V25Lwr8/m5pkWBdTH6FSV8LhzV84RW/hC",
+	"6GcWRCaucmB0jM2MZW4BTEWgkq6/vUadn6Z3Ph2w9x4dK4STi7D9iSvETzz6zJYi98CUZkpLUxBCbz+e",
+	"4QM+BX+qhFv4yysLGR9fROeiVQ3ULqukjvifR94tjnNV868dduEzBVr2oVO/QeYWwjG3UMhkkMKk0Iws",
+	"AHQ84cpB0U+MekNYK1b7hiGq7AsDSlP2iJvS9pMZ3Yc1QTuBHByc1vnexRW9lIDY421+I1bInPUw2Hp1",
+	"ZUwOQnf0rcWQypj+HU1A2z2K3il0zMxYeM8KQBRzwP1dr/Vc9qTqwdQUlXVxSieEUivjZ8YWwvEx915l",
+	"D2RkOvlRrB5RrAKe/RUrucuXyw21zstMOPjRtA6ZB1XC9+xEJ1ZoF3xdn8FHtZ2+rA+msBeDEYv2sHSy",
+	"V+L3B2myfaLicnx/DwNpwd1jXsO6aTzXkbAjuzZ4XgbslZ6ZnmYJ0lvlVuwsEH0KdqkksF+mZ9Nf2Xuh",
+	"xRwK0n/0IWUKmdBhRZQp6CURYHo2ZdLomZp7G6ZaDH1NuRzuV9AWzRO+BIvRpNFgNHhO2JgStCgVH/OX",
+	"g9HgJU94KdwihHwoSjVcPh/G1o7D27hIJ1V0kXozrYhfwaY0C1Gh/SYJSaQVBTigDnrRTxLZIIiibTJj",
+	"jfOYr1XzZiiovSeNsX43sarqMmnfHV6MRk92bbgzqvTcH6Zxypj5nDWOJRx9UQi72kAXCBBB2VJaUOG9",
+	"aOZ2rNzzyOt2CE7A/e/wbzr8reAn/NXo1X2CN5YON1fMdrROwCGjhCenqQaJK+PdNnjbwjK4P4JVskmz",
+	"2BpweKuyb0iwdN2DdsY2jl1RMnXWWmZviEPI/gPJZR9MrhqPG+Vi952rJWiWTppxivjuTrJ45vUqpMWj",
+	"4jAPbeawglAzbi/wQ65skb9a7UC7pKmoi3ecTvejvY+T7T+GeLjvvjbZ6onBrifyqj2BkInVdxroaHEj",
+	"1v1RbpQ9B1qE6SIu0km1HjjC9GqwJ/e6v1weIMRZkE1UKK1ZKhqCQua3ep/XWaBWD0nWtn2PVOmC8S/z",
+	"ZZ/W2yJN9KAx98hHtM0e/tSd9CH+PKaWuA2BZPh2XVyUPlTCNLP8MGpLgyY7a0tV/R0AAP//YhK7rDIY",
+	"AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -46,12 +46,6 @@ type DeleteResponse struct {
 	Success bool `json:"success"`
 }
 
-// Error defines model for Error.
-type Error struct {
-	// Errors List of error messages
-	Errors []string `json:"errors"`
-}
-
 // Issuer defines model for Issuer.
 type Issuer struct {
 	// ClaimMappings CEL expressions mapping token claims to other claims
@@ -100,9 +94,6 @@ type OAuthClient struct {
 	Secret *string `json:"secret,omitempty"`
 }
 
-// NotFound defines model for NotFound.
-type NotFound = Error
-
 // UpdateIssuerJSONRequestBody defines body for UpdateIssuer for application/json ContentType.
 type UpdateIssuerJSONRequestBody = IssuerUpdate
 
@@ -115,25 +106,24 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xY32/bNhD+VwhuDxug2O6PJ7+lcReoa7ciTtCHNCgY6mwzlUiNRzo1Av3vw5GyLUVK",
-	"XBvd0Gx9oyjq7vjd992dfcelKUqjQTvk4ztuAUujEcLDH8b9ZrzOaC2NdqAdLUVZ5koKp4we3qDRtIdy",
-	"AYWg1c8WZnzMfxpuDQ/jWxy+ttZYXlVVwjNAaVVJRviYnwEabyWwW4FMG8dmwS8drL8l0ycWhIMU0YOl",
-	"59KaEqxTMVqZC1V8KkRZKj0POyLLFDkQ+fvWSbcqgY85Oqv0nHeCOXn9lsGX0gKiMhpZbZI58xk0C26Q",
-	"OcOMW4Ctn3mytmqub0A6snpz+xk/eavIZdvDmw+/T9nFWbr9qo4l4V+O5uZIiwLqY3SqSnjcuW/nmC18",
-	"IfSRBZGJ6xwYHWMzY5lbAFMRqKR7396gLs7Se58O2DuPjhXCyUXY/sgV4kce78yWIvfAlGZKS1MQQm8+",
-	"nOOOO4X7VAm38JdXFjI+voyXi1E1ULuqkjrjfx57tzjJVc2/dtqFzxRo2YdO/QaZWwjH3EIhk8EKk0Iz",
-	"igDQ8YQrB0U/MeoNYa1YHZqG6LKbhj4Q6M4TyMHBWS3E7oXRSwmIPWHkt2KFzFkPg627a2NyELrjb22G",
-	"XEZddjwBbfc4eqvQMTNj4T0rAFHMAfcA8l4otZ+rHg09GbGrrItTOiGUWlKcGVsIx8fce5XtkEo6+VFF",
-	"9qgiAc/+UpLc58vVhloXZSYc/OgmT5kHVcIPbBGnVmgX7ro+g3v1gz7Vh1DY88GIxXhYOjlI+P1Jmmyf",
-	"qLicPNBcEo4gLbgHwmtEN43ndrWnpro2eF4F7JWema6fKUhvlVux80D0KdilksB+mZ5Pf2XvhBZzKMj/",
-	"8fuUKWRChxVRpqCXRIDp+ZRJo2dq7m0YNzH0NeVyeNhB2zRP+BIsxpBGg9HgGWFjStCiVHzMXwxGgxc8",
-	"4aVwi5DyoSjVcPlsGLs2Du/iIp1U8YrUm2lF/AoxpVnICu03SUgmrSjAAXXQy36SyAZBFG1TGGucx3zt",
-	"mjdTQe09aczbjxOrqq6S9lD/fDT6ZvP8vVGlZ7Cfxilj5nPWOJZw9EUh7GoDXSBABGVLaUGF97Kp7Vi5",
-	"55HX7RScgvvf4d+88NeCn/CXo5cPGd5EOtz89mtn6xQcMhI8XZpqkLg23m2Tty0sg4czWCUbmcXWgMM7",
-	"lX2FwNJ1D3o0t3Hsipaps9Y2e1McUvYfEJfdKa4aj1vlYvedqyVolk6aeYr4Pi6yeObVKshirzzMQ5t5",
-	"WkmoGXcQ+EErW+SvV4+gXdJU1MU7TqeH0d7HyfYfQzz8en5lstU3BrueyKv2BEIhVt9pomPEjVz3Z7lR",
-	"9hxoEaaLuEgn1XrgCNOrwR7tdf8L2UGI82CbqFBas1Q0BAXlt3qf11mgVg9J1rF9j1TpgvEv8+WQ1tsi",
-	"TbxBY+6Re7TNHv7UnXQXf/apJW5DIBm+XRcXpZ8qYZoqfxq1pUGTR2tLVf0dAAD//3k5DefLFwAA",
+	"H4sIAAAAAAAC/+xYXW/bNhf+KwTf92IDFNtt73yXxkOgbsWKOEEv0qCgqWObqURq5KFTw9B/Hw4px7Kl",
+	"2LP3gXrrnUxR5+N5nvORrLg0RWk0aHR8uOJOzqEQ4fHKgkBInfNg6XdpTQkWFYS3Mheq+FyIslR6Fk5E",
+	"lilURov8w9ZNXJbAh9yhVXrGq4Rn4KRVJd3lQ3710y8MvpYWnFNGO1abZGi+gGbBjWNomME52Po3T9ZW",
+	"zeQRJJLVx6cv7rO3ilxue3j38ecxu7tJN1/VsST868XMXGhRQH2NblUJjye7di7Z3BdCX1gQmZjkwOga",
+	"mxrLcA5MRaCSdr6dQd3dpDuf9th775AVAuU8HH/iyrlPPObMFiL3wJRmSktTEELvPt66AzmFfKqEW/jN",
+	"KwsZH97H5GJUDdQeqqRm/NdLj/OrXIHGNu3CZwq07EKnfuMYzgUynCvHZLDCpNCMIgCHPOEKoegWRn0g",
+	"rBXLU2mILts0dIFAOY8gB4QbcKXRDtoJOy8lONcRRv4klo6h9dDbuJsYk4PQLX9rM+TybEpKZe200xEz",
+	"023BT40tBPIh915lBwSZjr7X6hG1GvDsLthkVy8bad2VmUD43rPPWQdVwk9sxNdWaAy5ru+4o7puV9WH",
+	"UNjr3oDFeFg6Oqnwu0kabX5Rc7l6oYUn3IG0gC+E14huHO8dGgLN6nrG8yFgr/TUtP2MQXqrcMlug9DH",
+	"YBdKAvthfDv+kb0XWsygIP+XH1KmHBM6PJFkCnpJAhjfjpk0eqpm3goy68L0UJjDyw62TfOEL8C6GNKg",
+	"N+i9ImxMCVqUig/5m96g94YnvBQ4D5T3Ran6i1f9OBtdfxUf0lEVU6QJSE+krxBTmgVW6LwpQjJpRQEI",
+	"1vHhfbdIZEMgio4pjDXOQ752zZtU0BBN6t2TAtkvrKp6oI/jxA4Jvh4MQn8zGutiEWWZKxmS6T86Cm/V",
+	"sP9/C1M+5P/rb5bffr359ncWgqCGHRXEWT71OWtcS7jzRSHs8hm6IIAIykbSghrvfbO2Y+eeRV1vU3AN",
+	"+J/Dv5nwSeBfAzpG9Us5UEsRE+Nxw8WmT/ReJqRKnqsmdnrXX6nsD9RLuh4pe6mKW1S0TIOyttnJWGDg",
+	"X1Ar9mCt1Hg8KYzDdKYWoFk6avIU8d1fM/HO22VQ+VE8zMLUOC8SasWdBH6olQ3yk+UetEtactp4x2Xz",
+	"NNn7uKj+bYiHPznfmmz5F4NdL9jV9kJBIVbfKNEx4gbX3Sw32h6CFmFZiA/pqFrvD2EZNa6j9tr/QDgg",
+	"iNtgm6RQWrNQtNOEyt8aZV5nQVodIlnH9i1KpQ3GP6yXPz1JYwaNNUYeMTY79FNP0kP6OaaX4LOAZPh2",
+	"3VyUPlfBNKv8PHpLQyZ7e0tV/R4AAP//z6Tyrm4WAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -33,14 +33,26 @@ type CreateIssuer struct {
 
 // CreateOAuthClient defines model for CreateOAuthClient.
 type CreateOAuthClient struct {
+	// Audience Audiences that this client can request
+	Audience *[]string `json:"audience,omitempty"`
+
 	// Name A human-readable name for the client
 	Name string `json:"name"`
+
+	// Scope Scopes that this client can request
+	Scope *[]string `json:"scope,omitempty"`
 }
 
 // DeleteResponse defines model for DeleteResponse.
 type DeleteResponse struct {
 	// Success Always true.
 	Success bool `json:"success"`
+}
+
+// Error defines model for Error.
+type Error struct {
+	// Errors List of error messages
+	Errors []string `json:"errors"`
 }
 
 // Issuer defines model for Issuer.
@@ -87,9 +99,15 @@ type OAuthClient struct {
 	// Name Description of Client
 	Name string `json:"name"`
 
+	// Scope Grantable scopes
+	Scope string `json:"scope"`
+
 	// Secret OAuth2.0 Client Secret
 	Secret *string `json:"secret,omitempty"`
 }
+
+// NotFound defines model for NotFound.
+type NotFound = Error
 
 // UpdateIssuerJSONRequestBody defines body for UpdateIssuer for application/json ContentType.
 type UpdateIssuerJSONRequestBody = IssuerUpdate
@@ -103,24 +121,26 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xXW2/bNhT+KwS3hw1QbLd981saD4G6FStiB31Ig4Kmjm2mEsny4tQw9N+HQ8qRbMn2",
-	"4l1Qb3mTaOpcvu87F68pV4VWEqSzdLimli+gYOHxygBzkFrrweC7NkqDcQLCrzxnovhcMK2FnIcTlmXC",
-	"CSVZ/mHrpltpoENqnRFyTsuEZmC5ERrv0iG9+uU3At+0AWuFkpZUJolTX0CS4MYSp4hyCzDVO002VtX0",
-	"AbhDqw+PX+xnbwS63Pbw7uOvY3J7k9ZfVbEk9NvFXF1IVkB1DW+VCY0nu3YuycIXTF4YYBmb5kDwGpkp",
-	"Q9wCiIhAJe18O4O6vUl3Pu2R9946UjDHF+H4ExXWfqIxZ7JkuQciJBGSqwIRevdxYo/kFPIpE2rgqxcG",
-	"Mjq8i8nFqBqo3ZdJxfjvl94trnIB0rVpPwUZHm21kOmKC8MYQQ4ObsBqJS20Y7Cec7C2I4z8ka0sccZD",
-	"r3Y3VSoHJlv+NmbQ5dmoXGTttNMRUbNtDc6UKZijQ+q9yI5oJB29lM8zyifg2V1Dya5eamnd6ow5eGmj",
-	"56yDMqEHeyPzmQDJO1K+Nky6kOvmDnoUDopuaqsDZgxb7av6EAp53RuQGA9JRycVfjdJo/oNm8vVnhae",
-	"UAvcgNsTXiO6cbx3bAg0q+sJz/uAvZAz1fYzBu6NcCsyCUIfg1kKDuSn8WT8M3nPJJtDgf4vP6REWMJk",
-	"eELJkAJ/RQWMJ2PClZyJuTcM7dowPoTLYb+Hbds0oUswNsY06A16rxAcpUEyLeiQvukNem9oQjVzi8B5",
-	"n2nRX77qx+Fo++v4kI7KmCOOQHxCgYWY0izQgudNFaJJwwpwYCwd3nWrhDcUIvAYw9gAPaQb17TJBU7R",
-	"pNoHMZDDyirLe/w4juyQ4OvBIDQ4JV1VLUzrXPCQTP/BYnjrhv0fDczokP7QrxfSfrWN9nc2giCHHRnE",
-	"YT7zOWlcS6j1RcHM6gm6oIAISq1php33rlncsXXPo7C3KbgG97/Dv5nwSeBfg7MECxhzwJ7Cpsq7mou6",
-	"UfT2E1ImT1UTW73tr0X2J+ol3cyUg1TFNSpaxklZ2exkLDDwH6gVc7RWKjwehYvTdC6WIEk6avIU8T1c",
-	"M/HO21VQ+bN4mIexcV4kVIo7CfxQKzXy09UBtDVuOW2847Z5mux93FT/McS/erDurcpWfzPY1YZdbm8U",
-	"GGL5nRIdI25w3c1yo+05kCwsC/EhHZWb/SFso8p21F77T/0RQUyCbZSCNmopcKcJlb81yrzMgrQ6RLKJ",
-	"7XuUShuMf1kvf3mSxgwaawx/xtjs0E81SY/p5zm9xD0JiIdvN81FyHMVTLPKz6O3NGRysLeU5R8BAAD/",
-	"/6ai6JUCFgAA",
+	"H4sIAAAAAAAC/+xY3W/bNhD/Vw7cHjZAtd2PJ7+1cReoa7ciTtCHNCho6mwzlUiNRyU1Av3vw5GyLceK",
+	"ExvZ0Gx9oyjqPn73uw/qRihblNag8SSGN8IhldYQhoc/rP/NVibjtbLGo/G8lGWZayW9tqZ/SdbwHqk5",
+	"FpJXPzuciqH4qb8W3I9vqf/WOetEXdeJyJCU0yULEUNxgmQrpxCuJYGxHqZBLx9svmXRRw6lx5SoQsfP",
+	"pbMlOq+jtSqXuvhSyLLUZhZ2ZJZpViDzjxsn/aJEMRTknTYzsWXM0dv3gN9Kh0TaGoJGJHj7FQ0ENQTe",
+	"gvVzdM2zSJZS7eQSlWepl9df6UvlNKvc1PDu0+9jODtJ1181tiTi27OZfWZkgc0xPlUnIu7clvMa5lUh",
+	"zTOHMpOTHIGPwdQ68HMEHYFKtv3tNOrsJL31aQ8+VOShkF7Nw/ZnoYk+i+gzXMm8QtAGtFG2YITefTql",
+	"e3wK/tSJcPhXpR1mYngenYtWtVC7qJMm4n++rvz8KNcN/zbDLqtMo1Fd6DRvCPxcevBzTaCCFFDSAFuA",
+	"5EUitMeimxjNhnROLg4NQ1TZFQZStuwQN+btRzO6C2uGdoQ5ejxp8n0bV6qUQqIOb/NruSDwrsLe2quJ",
+	"tTlKs6VvKYZVxvTf0oS83aHovSYPdgrhPRRIJGdIh7ve6LnoSNUnU1N0to1TOmKUNjJ+al0hvRiKqtLZ",
+	"PRmZjn4Uqz2KVcCzu2Ilt/lysaLWWZlJjz+a1lPmQZ2IAzvRsZPGB1+XZ2ivttOV9cEUeNEbQLQH0tFB",
+	"id8dpNH6iYvL0b49bO1xOECdn6Jy6O/wrOXYOJ7bkrAjMVehWBp4EcKnzdR29FtUldN+AachV8borrRC",
+	"+GV8Ov4VPkgjZ1iwHa8/pqAJpAkrZh0U/JZJND4dg7JmqmeVC5Mxhd6ofY53a9iULRJxhY6iTYPeoPec",
+	"QbIlGllqMRQve4PeS5GIUvp5oE1flrp/9bwfxwPq38RFOqqjj9zfecUcDTalWYgs77eJzCKdLNAjd+Hz",
+	"bqKpFsk0b7MZS8CHYqlatGPCI0LSuhrsJmddXySb948Xg8GjXT1ujTsdd5BxnFSmVQ6tY4mgqiikWyyh",
+	"CwTYhM9LLt3n7eoQa/8s0nszAMfo/3fotx1+KPSJeDV4dZfglaX91SV1M1bHHCnOd3aaq5ic2MqvYtcq",
+	"nL27I1gnqySLzYX6Nzp7QHqlyy62M7ZxcIuSuTc3MjtDHEL2H0gttyO1MORWg8e19rF/z/QVGkhH7ThF",
+	"fHcnWTzzZhHSYq84zEK3eVpBaBh3EPjHTVVrEJgsdqBd8ly1jXecbw+jfRVn438M8XBjfmOzxSOD3cz0",
+	"9eYgwibW32mgo8WtWHdHuVX2PBoZZou4SEf1ctwI86+ljtzb/mmzT4+jua3yDCYIEy7rTJDwE2RpQDdP",
+	"Wm+/O7Zs4/EvU+aQ7rvBm+hB4I2V61g9rHN2UKhppvdRaJ9yEoUzW1T4dllftHmqhGkn+tMoLy2a7Cwv",
+	"df13AAAA///CDzWIdxgAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
This depends on https://github.com/infratographer/identity-api/pull/87. This adds the API endpoints to create, read and delete clients.

The create endpoint binds a OAuth 2.0 client to a tenant, and returns a client id and secret to be used in a later PR for the client credentials flow.
