### PR TITLE
CRDB Helm chart support

### DIFF
--- a/chart/identity-api/templates/_helpers.tpl
+++ b/chart/identity-api/templates/_helpers.tpl
@@ -1,18 +1,4 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Create the SeedIssuer object to bootstrap the token exchange with an issuer.
-*/}}
-{{- define "idapi.seedIssuer" }}
-          - tenantID: {{ .tenantID }}
-            id:  {{ .id }}
-            name: {{ .name }}
-            uri:  {{ .uri }}
-            jwksURI: {{ .jwksURI }}
-            claimMappings:
-            {{- range $k, $v := .claimMappings }}
-              {{ $k | quote }}: {{ $v | quote }}
-            {{- end }}
-{{- end }}
 
 {{- define "idapi.listenPort" }}
 {{- .Values.config.server.port | default 8080 }}

--- a/chart/identity-api/templates/configMap.yaml
+++ b/chart/identity-api/templates/configMap.yaml
@@ -32,7 +32,7 @@ data:
         {{- end }}
         {{- end }}
     storage:
-      type: {{ .storage.type | default "memory" }}
+      type: crdb
       seedData:
         issuers:
           {{- range $k, $v := .storage.seedData.issuers }}

--- a/chart/identity-api/templates/configMap.yaml
+++ b/chart/identity-api/templates/configMap.yaml
@@ -33,9 +33,4 @@ data:
         {{- end }}
     storage:
       type: crdb
-      seedData:
-        issuers:
-          {{- range $k, $v := .storage.seedData.issuers }}
-          {{- template "idapi.seedIssuer" $v }}
-          {{- end }}
   {{- end }}

--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -51,9 +51,14 @@ spec:
               mountPath: /keys/
       containers:
         - name: {{ include "common.names.name" . }}
+          env:
+            - name: PGSSLROOTCERT
+              value: /etc/ssl/certs/crdb/ca.crt
           envFrom:
             - secretRef:
                 name: "{{ .Values.config.oauth.secretName }}"
+            - secretRef:
+                name: "{{ .Values.config.storage.crdb.uriSecretName }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           volumeMounts:
@@ -62,6 +67,8 @@ spec:
               readOnly: true
             - name: app-config
               mountPath: /etc/identity-api/
+            - name: crdb-ca
+              mountPath: /etc/ssl/crdb/
           ports:
             - name: web
               containerPort: {{ include "idapi.listenPort" . }}
@@ -79,3 +86,6 @@ spec:
         - name: app-config
           configMap:
             name: {{ include "common.names.name" . }}-app-config
+        - name: crdb-ca
+          secret:
+            secretName: {{ .Values.config.storage.crdb.caSecretName }}

--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -49,6 +49,24 @@ spec:
               mountPath: /sts-keys/
             - name: signing-keys
               mountPath: /keys/
+        {{- if .Values.config.storage.migrateOnInit }}
+        - name: db-migrate
+          env:
+            - name: PGSSLROOTCERT
+              value: /etc/ssl/certs/crdb/ca.crt
+          envFrom:
+            - secretRef:
+                name: "{{ .Values.config.storage.crdb.uriSecretName }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          command:
+            - migrate
+          volumeMounts:
+            - name: app-config
+              mountPath: /etc/identity-api/
+            - name: crdb-ca
+              mountPath: /etc/ssl/crdb/
+        {{- end }}
       containers:
         - name: {{ include "common.names.name" . }}
           env:

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -33,7 +33,9 @@ config:
       prettyPrint: true
 
   storage:
-    type: memory
+    crdb:
+      caSecretName: ""
+      uriSecretName: ""
 
     # Configure the issuers to trust upon initial deployment
     seedData:

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -33,6 +33,8 @@ config:
       prettyPrint: true
 
   storage:
+    migrateOnInit: false
+
     crdb:
       caSecretName: ""
       uriSecretName: ""

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -37,21 +37,6 @@ config:
       caSecretName: ""
       uriSecretName: ""
 
-    # Configure the issuers to trust upon initial deployment
-    seedData:
-
-      # Issuers is how you configure the issuers to trust when
-      # bootstrapping the application issuers is a map with the
-      # following format:
-      # ```yaml
-      #   - name: "Example"
-      #     uri: "https://auth.example.com/"
-      #     jwksURI: "https://auth.example.com/.well-known/jwks.json"
-      #     claimMappings:
-      #       "infratographer:sub": "'infratographer://example.com/' + subSHA256"
-      #```
-      issuers: []
-
   oauth:
     # issuer is the `iss` claim in the exchanged tokens
     issuer: ""


### PR DESCRIPTION
This PR updates the identity-api Helm chart with configuration items for CockroachDB storage. Additionally, in-memory storage support is removed because it's not really useful in the context of multi-replica or persistent deployments.