### PR TITLE
Add OAuth 2.0 Client credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 identity-api is an OAuth service that supports the following grant types:
 
-* [RFC 8693][rfc8693]: Token Exchange
+* Token Exchange: [RFC 8693][rfc8693]
+* Client Credentials: [RFC 6749][oauth2-client_credentials]
 
 [rfc8693]: https://www.rfc-editor.org/rfc/rfc8693.html
+[oauth2-client_credentials]: https://www.rfc-editor.org/rfc/rfc6749#section-4.4
 
 ## Usage
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/ory/fosite/compose"
-	fositestorage "github.com/ory/fosite/storage"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.infratographer.com/x/crdbx"
@@ -18,6 +17,7 @@ import (
 	"go.infratographer.com/identity-api/internal/config"
 	"go.infratographer.com/identity-api/internal/fositex"
 	"go.infratographer.com/identity-api/internal/jwks"
+	"go.infratographer.com/identity-api/internal/oauth2"
 	"go.infratographer.com/identity-api/internal/rfc8693"
 	"go.infratographer.com/identity-api/internal/routes"
 	"go.infratographer.com/identity-api/internal/storage"
@@ -83,13 +83,13 @@ func serve(ctx context.Context) {
 
 	hmacStrategy := compose.NewOAuth2HMACStrategy(oauth2Config)
 	jwtStrategy := compose.NewOAuth2JWTStrategy(keyGetter, hmacStrategy, oauth2Config)
-	store := fositestorage.NewExampleStore()
 
 	provider := fositex.NewOAuth2Provider(
 		oauth2Config,
-		store,
+		storageEngine,
 		jwtStrategy,
 		rfc8693.NewTokenExchangeHandler,
+		oauth2.NewClientCredentialsHandlerFactory,
 	)
 
 	apiHandler, err := httpsrv.NewAPIHandler(storageEngine)

--- a/data.example.yaml
+++ b/data.example.yaml
@@ -1,4 +1,9 @@
 issuers:
+  - tenantID: 00000000-0000-0000-0000-000000000001
+    id: 00000000-0000-0000-0000-000000000001
+    name: "self"
+    uri: "https://dmv.infratographer.com/"
+    jwksURI: "blah"
   - tenantID: 67787b34-866e-4b75-a395-5aba096b2c1b
     id: 54f1973b-f7df-4b80-86ab-2238a934d7bb
     name: "Example"

--- a/data.example.yaml
+++ b/data.example.yaml
@@ -1,9 +1,4 @@
 issuers:
-  - tenantID: 00000000-0000-0000-0000-000000000001
-    id: 00000000-0000-0000-0000-000000000001
-    name: "self"
-    uri: "https://dmv.infratographer.com/"
-    jwksURI: "blah"
   - tenantID: 67787b34-866e-4b75-a395-5aba096b2c1b
     id: 54f1973b-f7df-4b80-86ab-2238a934d7bb
     name: "Example"

--- a/internal/fositex/config.go
+++ b/internal/fositex/config.go
@@ -75,6 +75,12 @@ type UserInfoStrategy interface {
 	types.UserInfoService
 }
 
+// UserInfoAudienceProvider returns the user info audience to attach to tokens
+type UserInfoAudienceProvider interface {
+	// GetUserInfoAudience returns the audience for the identity-api issuer
+	GetUserInfoAudience() string
+}
+
 // UserInfoStrategyProvider represents the provider of the UserInfoStrategy.
 type UserInfoStrategyProvider interface {
 	GetUserInfoStrategy(ctx context.Context) UserInfoStrategy
@@ -98,6 +104,8 @@ type OAuth2Config struct {
 	IssuerJWKSURIStrategy IssuerJWKSURIStrategy
 	ClaimMappingStrategy  ClaimMappingStrategy
 	UserInfoStrategy      UserInfoStrategy
+
+	userInfoAudience string
 }
 
 // GetIssuerJWKSURIStrategy returns the config's IssuerJWKSURIStrategy.
@@ -123,6 +131,11 @@ func (c *OAuth2Config) GetClaimMappingStrategy(ctx context.Context) ClaimMapping
 // GetUserInfoStrategy returns the config's user info store strategy.
 func (c *OAuth2Config) GetUserInfoStrategy(ctx context.Context) UserInfoStrategy {
 	return c.UserInfoStrategy
+}
+
+// GetUserInfoAudience returns this services userinfo audience.
+func (c *OAuth2Config) GetUserInfoAudience() string {
+	return c.userInfoAudience
 }
 
 // MustViperFlags sets the flags needed for Fosite to work.

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -9,6 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"time"
 
@@ -147,10 +148,16 @@ func NewOAuth2Config(config Config) (*OAuth2Config, error) {
 		GlobalSecret:        []byte(config.Secret),
 	}
 
+	userInfoAudience, err := url.JoinPath(config.Issuer, "userinfo")
+	if err != nil {
+		return nil, err
+	}
+
 	out := &OAuth2Config{
-		Config:      fositeConfig,
-		SigningKey:  signingKey,
-		SigningJWKS: jwks,
+		Config:           fositeConfig,
+		SigningKey:       signingKey,
+		SigningJWKS:      jwks,
+		userInfoAudience: userInfoAudience,
 	}
 
 	return out, nil

--- a/internal/oauth2/flow_client_credentials.go
+++ b/internal/oauth2/flow_client_credentials.go
@@ -1,0 +1,135 @@
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ory/x/errorsx"
+	"go.infratographer.com/identity-api/internal/fositex"
+	"go.infratographer.com/identity-api/internal/storage"
+	"go.infratographer.com/identity-api/internal/types"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/token/jwt"
+)
+
+var _ fosite.TokenEndpointHandler = &ClientCredentialsGrantHandler{}
+
+type ClientCredentialsConfigurator interface {
+	fosite.ScopeStrategyProvider
+	fosite.AudienceStrategyProvider
+	fosite.AccessTokenLifespanProvider
+	fosite.AccessTokenIssuerProvider
+	fositex.UserInfoAudienceProvider
+	fositex.SigningKeyProvider
+}
+
+type ClientCredentialsGrantHandler struct {
+	*oauth2.HandleHelper
+	types.UserInfoService
+	storage.TransactionManager
+	Config ClientCredentialsConfigurator
+}
+
+// HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-4.4.2
+func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
+
+	client := request.GetClient()
+	// The client MUST authenticate with the authorization server as described in Section 3.2.1.
+	// This requirement is already fulfilled because fosite requires all token requests to be authenticated as described
+	// in https://tools.ietf.org/html/rfc6749#section-3.2.1
+	if client.IsPublic() {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is marked as public and is not allowed to use authorization grant 'client_credentials'."))
+	}
+
+	for _, scope := range request.GetRequestedScopes() {
+		if !c.Config.GetScopeStrategy(ctx)(client.GetScopes(), scope) {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+	}
+
+	if err := c.Config.GetAudienceStrategy(ctx)(client.GetAudience(), request.GetRequestedAudience()); err != nil {
+		return err
+	}
+
+	// First grant the /userinfo audience
+	request.GrantAudience(c.Config.GetUserInfoAudience())
+
+	// grant audiences, we checked if they were permitted above
+	for _, aud := range request.GetRequestedAudience() {
+		request.GrantAudience(aud)
+	}
+
+	atLifespan := fosite.GetEffectiveLifespan(client, fosite.GrantTypeClientCredentials, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
+	session := request.GetSession().(*oauth2.JWTSession)
+
+	headers := jwt.Headers{}
+	headers.Add("kid", c.Config.GetSigningKey(ctx).KeyID)
+
+	session.JWTClaims = &jwt.JWTClaims{}
+	session.JWTClaims.Add("client_id", request.GetClient().GetID())
+
+	session.JWTHeader = &headers
+	session.SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(atLifespan))
+
+	dbCtx, err := c.BeginContext(ctx)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithHintf("could not start transaction: %v", err))
+	}
+
+	userInfo := types.UserInfo{
+		Issuer:  c.Config.GetAccessTokenIssuer(ctx),
+		Subject: request.GetClient().GetID(),
+	}
+
+	uiWithId, err := c.StoreUserInfo(dbCtx, userInfo)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithHintf("unable to create user info for client: %v", err))
+	}
+
+	if err := c.CommitContext(dbCtx); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithHintf("unable to store userinfo for client: %v", err))
+	}
+
+	session.JWTClaims.Subject = fmt.Sprintf("urn:infratographer:user/%s", uiWithId.ID)
+
+	return nil
+}
+
+// PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.4.3
+func (c *ClientCredentialsGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, request fosite.AccessRequester, response fosite.AccessResponder) error {
+	// fosite doesn't check if this is the right handler on calls to this function.
+	if !c.CanHandleTokenEndpointRequest(ctx, request) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	atLifespan := fosite.GetEffectiveLifespan(request.GetClient(), fosite.GrantTypeClientCredentials, fosite.AccessToken, c.Config.GetAccessTokenLifespan(ctx))
+	return c.IssueAccessToken(ctx, atLifespan, request, response)
+}
+
+func (c *ClientCredentialsGrantHandler) CanSkipClientAuth(ctx context.Context, requester fosite.AccessRequester) bool {
+	return false
+}
+
+func (c *ClientCredentialsGrantHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) bool {
+	// grant_type REQUIRED.
+	// Value MUST be set to "client_credentials".
+	return requester.GetGrantTypes().ExactOne("client_credentials")
+}
+
+var _ fositex.Factory = NewClientCredentialsHandlerFactory
+
+func NewClientCredentialsHandlerFactory(config fositex.OAuth2Configurator, store any, strategy any) any {
+	return &ClientCredentialsGrantHandler{
+		HandleHelper: &oauth2.HandleHelper{
+			AccessTokenStrategy: strategy.(oauth2.AccessTokenStrategy),
+			AccessTokenStorage:  store.(oauth2.AccessTokenStorage),
+			Config:              config,
+		},
+		UserInfoService:    store.(types.UserInfoService),
+		TransactionManager: store.(storage.TransactionManager),
+		Config:             config.(ClientCredentialsConfigurator),
+	}
+}

--- a/internal/oauth2/flow_client_credentials.go
+++ b/internal/oauth2/flow_client_credentials.go
@@ -43,12 +43,18 @@ func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.C
 		return errorsx.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is marked as public and is not allowed to use authorization grant 'client_credentials'."))
 	}
 
-	if err := c.Config.GetAudienceStrategy(ctx)(client.GetAudience(), request.GetRequestedAudience()); err != nil {
+	requestedResources := request.GetRequestForm()["resource"]
+
+	resources := make([]string, 0)
+	for _, r := range requestedResources {
+		resources = append(resources, string(r))
+	}
+
+	if err := c.Config.GetAudienceStrategy(ctx)(client.GetAudience(), fosite.Arguments(resources)); err != nil {
 		return err
 	}
 
-	// grant audiences, we checked if they were permitted above
-	for _, aud := range request.GetRequestedAudience() {
+	for _, aud := range resources {
 		request.GrantAudience(aud)
 	}
 

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -291,6 +291,10 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 
 // PopulateTokenEndpointResponse populates the response with a token.
 func (s *TokenExchangeHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
+	if !s.CanHandleTokenEndpointRequest(ctx, requester) {
+		return errorsx.WithStack(fosite.ErrUnknownRequest)
+	}
+
 	token, _, err := s.accessTokenStrategy.GenerateAccessToken(ctx, requester)
 	if err != nil {
 		return err

--- a/internal/storage/crdb.go
+++ b/internal/storage/crdb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/ory/fosite"
 	"go.infratographer.com/x/crdbx"
 )
 
@@ -12,6 +13,21 @@ type engine struct {
 	*userInfoService
 	*oauthClientManager
 	db *sql.DB
+}
+
+// CreateAccessTokenSession implements oauth2.AccessTokenStorage
+func (*engine) CreateAccessTokenSession(ctx context.Context, signature string, request fosite.Requester) (err error) {
+	return nil
+}
+
+// DeleteAccessTokenSession implements oauth2.AccessTokenStorage
+func (*engine) DeleteAccessTokenSession(ctx context.Context, signature string) (err error) {
+	panic("unimplemented")
+}
+
+// GetAccessTokenSession implements oauth2.AccessTokenStorage
+func (*engine) GetAccessTokenSession(ctx context.Context, signature string, session fosite.Session) (request fosite.Requester, err error) {
+	panic("unimplemented")
 }
 
 func newCRDBEngine(config crdbx.Config, options ...EngineOption) (*engine, error) {


### PR DESCRIPTION
This depends on https://github.com/infratographer/identity-api/pull/90. This allows for the client_id and client_secret created in the management API to be used to authenticat against the i-api and grab a token directly instead of exchanging a JWT.