### PR TITLE
Use /etc/ssl/crdb for CRDB cert, not /etc/ssl/certs/crdb

### DIFF
--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: db-migrate
           env:
             - name: PGSSLROOTCERT
-              value: /etc/ssl/certs/crdb/ca.crt
+              value: /etc/ssl/crdb/ca.crt
           envFrom:
             - secretRef:
                 name: "{{ .Values.config.storage.crdb.uriSecretName }}"
@@ -71,7 +71,7 @@ spec:
         - name: {{ include "common.names.name" . }}
           env:
             - name: PGSSLROOTCERT
-              value: /etc/ssl/certs/crdb/ca.crt
+              value: /etc/ssl/crdb/ca.crt
           envFrom:
             - secretRef:
                 name: "{{ .Values.config.oauth.secretName }}"


### PR DESCRIPTION
The Helm chart template had a misconfigured value for SSL certs. This PR fixes the chart to use the correct value.