### PR TITLE
Set migration resources

### DIFF
--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -61,6 +61,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           command:
             - migrate
+          {{- with .Values.deployment.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: app-config
               mountPath: /etc/identity-api/

--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -60,6 +60,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           command:
+            - /app/identity-api
             - migrate
           {{- with .Values.deployment.resources }}
           resources:


### PR DESCRIPTION
This PR sets init container resources for the `db-migrate` init container and also uses the correct command in the container spec.