### PR TITLE
Rename IssuerJWKSURIStrategy to IssuerJWKSURIProvider

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -66,14 +66,14 @@ func serve(ctx context.Context) {
 
 	mappingStrategy := rfc8693.NewClaimMappingStrategy(storageEngine)
 
-	jwksStrategy := jwks.NewIssuerJWKSURIStrategy(storageEngine)
+	issuerJWKSURIProvider := jwks.NewIssuerJWKSURIProvider(storageEngine)
 
 	oauth2Config, err := fositex.NewOAuth2Config(config.Config.OAuth)
 	if err != nil {
 		logger.Fatalf("error loading config: %s", err)
 	}
 
-	oauth2Config.IssuerJWKSURIStrategy = jwksStrategy
+	oauth2Config.IssuerJWKSURIProvider = issuerJWKSURIProvider
 	oauth2Config.ClaimMappingStrategy = mappingStrategy
 	oauth2Config.UserInfoStrategy = storageEngine
 

--- a/internal/fositex/config.go
+++ b/internal/fositex/config.go
@@ -40,14 +40,9 @@ type Config struct {
 	PrivateKeys []PrivateKey
 }
 
-// IssuerJWKSURIStrategy represents a strategy for getting the JWKS URI for a given issuer.
-type IssuerJWKSURIStrategy interface {
+// IssuerJWKSURIProvider represents a provider for the JWKS URI for a given issuer.
+type IssuerJWKSURIProvider interface {
 	GetIssuerJWKSURI(ctx context.Context, iss string) (string, error)
-}
-
-// IssuerJWKSURIStrategyProvider represents a provider for a IssuerJWKSURIStrategy.
-type IssuerJWKSURIStrategyProvider interface {
-	GetIssuerJWKSURIStrategy(ctx context.Context) IssuerJWKSURIStrategy
 }
 
 // SigningKeyProvider represents a provider of a signing key.
@@ -89,28 +84,29 @@ type UserInfoStrategyProvider interface {
 // OAuth2Configurator represents an OAuth2 configuration.
 type OAuth2Configurator interface {
 	fosite.Configurator
-	IssuerJWKSURIStrategyProvider
 	SigningKeyProvider
 	SigningJWKSProvider
 	ClaimMappingStrategyProvider
 	UserInfoStrategyProvider
+	GetIssuerJWKSURIProvider(ctx context.Context) IssuerJWKSURIProvider
 }
 
 // OAuth2Config represents a Fosite OAuth 2.0 provider configuration.
 type OAuth2Config struct {
 	*fosite.Config
-	SigningKey            *jose.JSONWebKey
-	SigningJWKS           *jose.JSONWebKeySet
-	IssuerJWKSURIStrategy IssuerJWKSURIStrategy
-	ClaimMappingStrategy  ClaimMappingStrategy
-	UserInfoStrategy      UserInfoStrategy
+	SigningKey  *jose.JSONWebKey
+	SigningJWKS *jose.JSONWebKeySet
 
-	userInfoAudience string
+	ClaimMappingStrategy ClaimMappingStrategy
+	UserInfoStrategy     UserInfoStrategy
+
+	IssuerJWKSURIProvider IssuerJWKSURIProvider
+	userInfoAudience      string
 }
 
-// GetIssuerJWKSURIStrategy returns the config's IssuerJWKSURIStrategy.
-func (c *OAuth2Config) GetIssuerJWKSURIStrategy(ctx context.Context) IssuerJWKSURIStrategy {
-	return c.IssuerJWKSURIStrategy
+// GetIssuerJWKSURIProvider returns the config's IssuerJWKSURIProvider.
+func (c *OAuth2Config) GetIssuerJWKSURIProvider(ctx context.Context) IssuerJWKSURIProvider {
+	return c.IssuerJWKSURIProvider
 }
 
 // GetSigningKey returns the config's signing key.

--- a/internal/jwks/strategy.go
+++ b/internal/jwks/strategy.go
@@ -1,4 +1,4 @@
-// Package jwks provides a fosite.IssuerJWKSURIStrategy implementation.
+// Package jwks provides a fositex.IssuerJWKSURIProvider implementation.
 package jwks
 
 import (
@@ -14,20 +14,20 @@ var (
 	ErrUnknownIssuer = fmt.Errorf("unknown JWT issuer")
 )
 
-type issuerJWKSURIStrategy struct {
+type issuerJWKSURIProvider struct {
 	issuerSvc types.IssuerService
 }
 
-// NewIssuerJWKSURIStrategy creates a new fosite.IssuerJWKSURIStrategy.
-func NewIssuerJWKSURIStrategy(issuerSvc types.IssuerService) fositex.IssuerJWKSURIStrategy {
-	out := issuerJWKSURIStrategy{
+// NewIssuerJWKSURIProvider creates a new fositex.IssuerJWKSURIProvider.
+func NewIssuerJWKSURIProvider(issuerSvc types.IssuerService) fositex.IssuerJWKSURIProvider {
+	out := issuerJWKSURIProvider{
 		issuerSvc: issuerSvc,
 	}
 
 	return out
 }
 
-func (s issuerJWKSURIStrategy) GetIssuerJWKSURI(ctx context.Context, iss string) (string, error) {
+func (s issuerJWKSURIProvider) GetIssuerJWKSURI(ctx context.Context, iss string) (string, error) {
 	issuer, err := s.issuerSvc.GetIssuerByURI(ctx, iss)
 	if err != nil {
 		return "", err

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -39,8 +39,8 @@ const (
 )
 
 var (
-	// ErrJWKSURIStrategyNotDefined is returned when the issuer JWKS URI strategy is not defined.
-	ErrJWKSURIStrategyNotDefined = errors.New("no issuer JWKS URI strategy defined")
+	// ErrJWKSURIProviderNotDefined is returned when the issuer JWKS URI provider is not defined.
+	ErrJWKSURIProviderNotDefined = errors.New("no issuer JWKS URI provider defined")
 )
 
 func findMatchingKey(ctx context.Context, config fositex.OAuth2Configurator, token *jwt.Token) (interface{}, error) {
@@ -55,15 +55,15 @@ func findMatchingKey(ctx context.Context, config fositex.OAuth2Configurator, tok
 		}
 	}
 
-	jwksURIStrategy := config.GetIssuerJWKSURIStrategy(ctx)
-	if jwksURIStrategy == nil {
+	jwksURIProvider := config.GetIssuerJWKSURIProvider(ctx)
+	if jwksURIProvider == nil {
 		return nil, &jwt.ValidationError{
 			Errors: jwt.ValidationErrorUnverifiable,
-			Inner:  ErrJWKSURIStrategyNotDefined,
+			Inner:  ErrJWKSURIProviderNotDefined,
 		}
 	}
 
-	jwksURI, err := jwksURIStrategy.GetIssuerJWKSURI(ctx, issuer)
+	jwksURI, err := jwksURIProvider.GetIssuerJWKSURI(ctx, issuer)
 	if err != nil {
 		return nil, &jwt.ValidationError{
 			Errors: jwt.ValidationErrorIssuer,


### PR DESCRIPTION
I didn't think the `Strategy` term made sense for this type because all it does is accept a issuer and return the URI. Strategy to me, implies there's some sort of logic to compute the JWKSURI that is able to be swapped out for other strategies.