### PR TITLE
Add relevant keywords to helm chart

### DIFF
--- a/chart/identity-api/Chart.yaml
+++ b/chart/identity-api/Chart.yaml
@@ -4,6 +4,9 @@ appVersion: v0.0.3
 description: A Helm chart for Identity-API - RFC 8693 token exchange server.
 name: identity-api
 keywords:
+  - identity
+  - oauth2
+  - rfc8693
 version: v0.0.3
 home: http://github.com/infratographer/identity-api
 dependencies:


### PR DESCRIPTION
To appease the Chart.yaml validation, this adds some relevant keywords
to the file. As an empty list of keywords was failing linting.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
