### PR TITLE
Use go 1.20 for everything

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.19-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20-bullseye
 
 USER vscode
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
 
       - name: Run go tests and generate coverage report
         run: make coverage

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.infratographer.com/identity-api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cockroachdb/cockroach-go/v2 v2.3.3


### PR DESCRIPTION
This switches go.mod to use 1.20 explicitly. It also makes the CI jobs
use the version directly from go.mod.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
