### PR TITLE
Fix new linter errors from golangci-lint

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -28,7 +28,7 @@ var migrateCmd = &cobra.Command{
 	},
 }
 
-func migrate(ctx context.Context) {
+func migrate(_ context.Context) {
 	logger.Info("running database migrations")
 
 	err := storage.RunMigrations(config.Config.CRDB)

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -32,7 +32,7 @@ var seedDatabaseCmd = &cobra.Command{
 	},
 }
 
-func seedDatabase(ctx context.Context) {
+func seedDatabase(_ context.Context) {
 	logger.Info("seeding database")
 
 	path := viper.GetString("data")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -47,7 +47,7 @@ func init() {
 	otelx.MustViperFlags(v, flags)
 }
 
-func serve(ctx context.Context) {
+func serve(_ context.Context) {
 	err := otelx.InitTracer(config.Config.OTel, appName, logger)
 	if err != nil {
 		logger.Fatalf("error initializing tracing: %s", err)

--- a/internal/fositex/config.go
+++ b/internal/fositex/config.go
@@ -105,27 +105,27 @@ type OAuth2Config struct {
 }
 
 // GetIssuerJWKSURIProvider returns the config's IssuerJWKSURIProvider.
-func (c *OAuth2Config) GetIssuerJWKSURIProvider(ctx context.Context) IssuerJWKSURIProvider {
+func (c *OAuth2Config) GetIssuerJWKSURIProvider(_ context.Context) IssuerJWKSURIProvider {
 	return c.IssuerJWKSURIProvider
 }
 
 // GetSigningKey returns the config's signing key.
-func (c *OAuth2Config) GetSigningKey(ctx context.Context) *jose.JSONWebKey {
+func (c *OAuth2Config) GetSigningKey(_ context.Context) *jose.JSONWebKey {
 	return c.SigningKey
 }
 
 // GetSigningJWKS returns the config's signing JWKS. This includes private keys.
-func (c *OAuth2Config) GetSigningJWKS(ctx context.Context) *jose.JSONWebKeySet {
+func (c *OAuth2Config) GetSigningJWKS(_ context.Context) *jose.JSONWebKeySet {
 	return c.SigningJWKS
 }
 
 // GetClaimMappingStrategy returns the config's claims mapping strategy.
-func (c *OAuth2Config) GetClaimMappingStrategy(ctx context.Context) ClaimMappingStrategy {
+func (c *OAuth2Config) GetClaimMappingStrategy(_ context.Context) ClaimMappingStrategy {
 	return c.ClaimMappingStrategy
 }
 
 // GetUserInfoStrategy returns the config's user info store strategy.
-func (c *OAuth2Config) GetUserInfoStrategy(ctx context.Context) UserInfoStrategy {
+func (c *OAuth2Config) GetUserInfoStrategy(_ context.Context) UserInfoStrategy {
 	return c.UserInfoStrategy
 }
 
@@ -135,7 +135,7 @@ func (c *OAuth2Config) GetUserInfoAudience() string {
 }
 
 // MustViperFlags sets the flags needed for Fosite to work.
-func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet, defaultListen string) {
+func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
 	flags.String("issuer", "", "oauth token issuer")
 	viperx.MustBindFlag(v, "oauth.issuer", flags.Lookup("issuer"))
 	flags.String("private-key", "", "private key file")

--- a/internal/oauth2/flow_client_credentials.go
+++ b/internal/oauth2/flow_client_credentials.go
@@ -90,12 +90,12 @@ func (c *ClientCredentialsGrantHandler) PopulateTokenEndpointResponse(ctx contex
 }
 
 // CanSkipClientAuth determines if the client must be authenticated to use this handler.
-func (c *ClientCredentialsGrantHandler) CanSkipClientAuth(ctx context.Context, requester fosite.AccessRequester) bool {
+func (c *ClientCredentialsGrantHandler) CanSkipClientAuth(_ context.Context, _ fosite.AccessRequester) bool {
 	return false
 }
 
 // CanHandleTokenEndpointRequest checks if this handler can handle the request.
-func (c *ClientCredentialsGrantHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) bool {
+func (c *ClientCredentialsGrantHandler) CanHandleTokenEndpointRequest(_ context.Context, requester fosite.AccessRequester) bool {
 	// grant_type REQUIRED.
 	// Value MUST be set to "client_credentials".
 	return requester.GetGrantTypes().ExactOne("client_credentials")

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -124,7 +124,7 @@ func NewTokenExchangeHandler(config fositex.OAuth2Configurator, storage any, str
 	}
 }
 
-func (s *TokenExchangeHandler) validateJWT(ctx context.Context, token string, strategy fosite.JWKSFetcherStrategy) (*jwt.Token, error) {
+func (s *TokenExchangeHandler) validateJWT(ctx context.Context, token string) (*jwt.Token, error) {
 	// Side effectful key finding isn't great but neither is parsing the JWT twice
 	keyfunc := func(token *jwt.Token) (interface{}, error) {
 		return findMatchingKey(ctx, s.config, token)
@@ -150,7 +150,7 @@ func (s *TokenExchangeHandler) validateJWT(ctx context.Context, token string, st
 }
 
 func (s *TokenExchangeHandler) getSubjectClaims(ctx context.Context, token string) (*jwt.JWTClaims, error) {
-	validated, err := s.validateJWT(ctx, token, s.config.GetJWKSFetcherStrategy(ctx))
+	validated, err := s.validateJWT(ctx, token)
 
 	if err != nil {
 		return nil, err
@@ -308,12 +308,12 @@ func (s *TokenExchangeHandler) PopulateTokenEndpointResponse(ctx context.Context
 }
 
 // CanSkipClientAuth always returns true, as client auth is not required for token exchange.
-func (s *TokenExchangeHandler) CanSkipClientAuth(ctx context.Context, requester fosite.AccessRequester) bool {
+func (s *TokenExchangeHandler) CanSkipClientAuth(_ context.Context, _ fosite.AccessRequester) bool {
 	return true
 }
 
 // CanHandleTokenEndpointRequest returns true if the grant type is token exchange.
-func (s *TokenExchangeHandler) CanHandleTokenEndpointRequest(ctx context.Context, requester fosite.AccessRequester) bool {
+func (s *TokenExchangeHandler) CanHandleTokenEndpointRequest(_ context.Context, requester fosite.AccessRequester) bool {
 	return requester.GetGrantTypes().ExactOne(GrantTypeTokenExchange)
 }
 

--- a/internal/storage/crdb.go
+++ b/internal/storage/crdb.go
@@ -16,17 +16,17 @@ type engine struct {
 }
 
 // CreateAccessTokenSession implements oauth2.AccessTokenStorage
-func (*engine) CreateAccessTokenSession(ctx context.Context, signature string, request fosite.Requester) (err error) {
+func (*engine) CreateAccessTokenSession(_ context.Context, _ string, _ fosite.Requester) (err error) {
 	return nil
 }
 
 // DeleteAccessTokenSession implements oauth2.AccessTokenStorage
-func (*engine) DeleteAccessTokenSession(ctx context.Context, signature string) (err error) {
+func (*engine) DeleteAccessTokenSession(_ context.Context, _ string) (err error) {
 	panic("unimplemented")
 }
 
 // GetAccessTokenSession implements oauth2.AccessTokenStorage
-func (*engine) GetAccessTokenSession(ctx context.Context, signature string, session fosite.Session) (request fosite.Requester, err error) {
+func (*engine) GetAccessTokenSession(_ context.Context, _ string, _ fosite.Session) (request fosite.Requester, err error) {
 	panic("unimplemented")
 }
 

--- a/internal/storage/oauth_client.go
+++ b/internal/storage/oauth_client.go
@@ -41,7 +41,7 @@ type oauthClientManager struct {
 }
 
 // ClientAssertionJWTValid implements fosite.ClientManager
-func (*oauthClientManager) ClientAssertionJWTValid(ctx context.Context, jti string) error {
+func (*oauthClientManager) ClientAssertionJWTValid(_ context.Context, _ string) error {
 	panic("unimplemented")
 }
 
@@ -51,7 +51,7 @@ func (s *oauthClientManager) GetClient(ctx context.Context, id string) (fosite.C
 }
 
 // SetClientAssertionJWT implements fosite.ClientManager
-func (*oauthClientManager) SetClientAssertionJWT(ctx context.Context, jti string, exp time.Time) error {
+func (*oauthClientManager) SetClientAssertionJWT(_ context.Context, _ string, _ time.Time) error {
 	panic("unimplemented")
 }
 


### PR DESCRIPTION
It appears that as of v1.52.0, golangci-lint now does a better job of finding unused function parameters. This PR fixes issues that the linter identified after the GH Action to run golangci-lint was updated.