### PR TITLE
Add tooling and updates to devcontainer

### DIFF
--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -1,0 +1,12 @@
+# cockroachdb container config
+COCKROACH_INSECURE=true
+COCKROACH_HOST=cockroachdb:26257
+COCKROACH_URL="postgresql://root@cockroachdb:26257/identity_api_dev?sslmode=disable"
+
+# postgresql client config
+PGHOST=crdb
+PGPORT=26257
+PGSSLMODE=disable
+PGDATABASE=identity_api_dev
+PGUSER=root
+PAGER="less -iMx4 -FXe"

--- a/.devcontainer/.env
+++ b/.devcontainer/.env
@@ -2,11 +2,3 @@
 COCKROACH_INSECURE=true
 COCKROACH_HOST=cockroachdb:26257
 COCKROACH_URL="postgresql://root@cockroachdb:26257/identity_api_dev?sslmode=disable"
-
-# postgresql client config
-PGHOST=crdb
-PGPORT=26257
-PGSSLMODE=disable
-PGDATABASE=identity_api_dev
-PGUSER=root
-PAGER="less -iMx4 -FXe"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,14 +23,10 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
         bash-completion \
         helm \
-        uuid-runtime \
-        postgresql-client
+        uuid-runtime
 
 USER vscode
 
-RUN go install -v github.com/cweill/gotests/gotests@v1.6.0 \
-    && go install github.com/volatiletech/sqlboiler/v4@latest \
-    && go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@latest \
-    && go install github.com/glerchundi/sqlboiler-crdb/v4@latest
+RUN go install -v github.com/cweill/gotests/gotests@v1.6.0
 
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,19 +26,11 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         uuid-runtime \
         postgresql-client
 
-# Install NATS Tooling
-RUN curl -o /tmp/install.sh  https://raw.githubusercontent.com/nats-io/nsc/main/install.sh \
-    && chmod +x /tmp/install.sh \
-    && su vscode -c "/tmp/install.sh -s /usr/local/bin" \
-    && rm -f /tmp/install.sh
-
 USER vscode
 
 RUN go install -v github.com/cweill/gotests/gotests@v1.6.0 \
     && go install github.com/volatiletech/sqlboiler/v4@latest \
     && go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@latest \
-    && go install github.com/glerchundi/sqlboiler-crdb/v4@latest \
-    && go install github.com/nats-io/natscli/nats@v0.0.35 \
-    && go install github.com/nats-io/nkeys/nk@latest
+    && go install github.com/glerchundi/sqlboiler-crdb/v4@latest
 
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,44 @@
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20-bullseye
+# Used to install CRDB into the devcontainer
+FROM cockroachdb/cockroach:latest-v22.2 as CRDB
 
-USER vscode
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-1.20-bullseye
 
 RUN mkdir /home/vscode/.ssh && \
     chown vscode:vscode /home/vscode/.ssh && \
     chmod 0700 /home/vscode/.ssh
+
+# Set up crdb
+RUN mkdir /usr/local/lib/cockroach
+COPY --from=CRDB /cockroach/cockroach /usr/local/bin
+COPY --from=CRDB /usr/local/lib/cockroach/libgeos.so /usr/local/lib/cockroach/
+COPY --from=CRDB /usr/local/lib/cockroach/libgeos_c.so /usr/local/lib/cockroach/
+
+# Install general use tooling
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg \
+    &&  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg \
+    && apt-get install apt-transport-https --yes \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends \
+        bash-completion \
+        helm \
+        uuid-runtime \
+        postgresql-client
+
+# Install NATS Tooling
+RUN curl -o /tmp/install.sh  https://raw.githubusercontent.com/nats-io/nsc/main/install.sh \
+    && chmod +x /tmp/install.sh \
+    && su vscode -c "/tmp/install.sh -s /usr/local/bin" \
+    && rm -f /tmp/install.sh
+
+USER vscode
+
+RUN go install -v github.com/cweill/gotests/gotests@v1.6.0 \
+    && go install github.com/volatiletech/sqlboiler/v4@latest \
+    && go install github.com/volatiletech/sqlboiler/v4/drivers/sqlboiler-psql@latest \
+    && go install github.com/glerchundi/sqlboiler-crdb/v4@latest \
+    && go install github.com/nats-io/natscli/nats@v0.0.35 \
+    && go install github.com/nats-io/nkeys/nk@latest
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	}
     },
     "features": {
-	    "ghcr.io/devcontainers/features/sshd:1": {}
+        "ghcr.io/devcontainers/features/sshd:1": {}
     },
     "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,13 +6,28 @@
     "shutdownAction": "stopCompose",
     "customizations": {
 	"vscode": {
-	    "extensions": [
-		"golang.Go"
-	    ]
+        "settings": {
+            "go.toolsManagement.checkForUpdates": "local",
+            "go.useLanguageServer": true,
+            "go.gopath": "/go",
+            "go.buildTags": "testtools"
+        },
+
+        // Add the IDs of extensions you want installed when the container is created.
+        "extensions": [
+            "2gua.rainbow-brackets",
+            "golang.Go",
+            "mutantdino.resourcemonitor",
+            "oderwat.indent-rainbow",
+            "ms-azuretools.vscode-docker",
+            "RemiMarche.cspell-tech",
+            "streetsidesoftware.code-spell-checker",
+            "netcorext.uuid-generator"
+        ]
 	}
     },
     "features": {
-	"ghcr.io/devcontainers/features/sshd:1": {}
+	    "ghcr.io/devcontainers/features/sshd:1": {}
     },
     "remoteUser": "vscode"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,8 +34,6 @@ services:
       - "--insecure"
     networks:
       idapinet:
-    ports:
-      - "9090:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
       interval: 10s

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       context: .
       dockerfile: Dockerfile
     command: sleep infinity
+    depends_on:
+      - cockroachdb
+    env_file:
+      - .env
     restart: unless-stopped
     ports:
       - "127.0.0.1:2222:2222"
@@ -31,7 +35,6 @@ services:
     networks:
       idapinet:
     ports:
-      - "26257:26257"
       - "9090:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ PHONY: deps generate test coverage lint golint clean vendor docker-up docker-dow
 GOOS=linux
 APP_NAME?=identity-api
 
+DB=identity_api
+DEV_DB="${DB}_dev"
+
 TEST_PRIVKEY_FILE?=tests/data/privkey.pem
 CONFIG_FILE?=identity-api.example.yaml
 
@@ -52,3 +55,10 @@ up: build $(TEST_PRIVKEY_FILE)
 
 $(TEST_PRIVKEY_FILE):
 	openssl genpkey -out $(TEST_PRIVKEY_FILE) -algorithm RSA -pkeyopt rsa_keygen_bits:4096
+
+dev-database: | vendor
+	@echo --- Creating dev database...
+	@date --rfc-3339=seconds
+	@cockroach sql -e "drop database if exists ${DEV_DB}"
+	@cockroach sql -e "create database ${DEV_DB}"
+	@go run main.go migrate --config=${CONFIG_FILE} up

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ dev-database: | build
 	@date --rfc-3339=seconds
 	@cockroach sql -e "drop database if exists ${DEV_DB}"
 	@cockroach sql -e "create database ${DEV_DB}"
-	@bin/${APP_NAME} migrate --config=${CONFIG_FILE} up
+	@bin/${APP_NAME} migrate --config=${CONFIG_FILE}

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ PHONY: deps generate test coverage lint golint clean vendor docker-up docker-dow
 GOOS=linux
 APP_NAME?=identity-api
 
-DB=identity_api
-DEV_DB="${DB}_dev"
+DEV_DB="identity_api_dev"
 
 TEST_PRIVKEY_FILE?=tests/data/privkey.pem
 CONFIG_FILE?=identity-api.example.yaml
@@ -56,9 +55,9 @@ up: build $(TEST_PRIVKEY_FILE)
 $(TEST_PRIVKEY_FILE):
 	openssl genpkey -out $(TEST_PRIVKEY_FILE) -algorithm RSA -pkeyopt rsa_keygen_bits:4096
 
-dev-database: | vendor
+dev-database: | build
 	@echo --- Creating dev database...
 	@date --rfc-3339=seconds
 	@cockroach sql -e "drop database if exists ${DEV_DB}"
 	@cockroach sql -e "create database ${DEV_DB}"
-	@go run main.go migrate --config=${CONFIG_FILE} up
+	@bin/${APP_NAME} migrate --config=${CONFIG_FILE} up

--- a/identity-api.example.yaml
+++ b/identity-api.example.yaml
@@ -14,4 +14,4 @@ otel:
   stdout:
     prettyPrint: true
 crdb:
-  uri: postgresql://root@cockroachdb:26257/defaultdb?sslmode=disable
+  uri: postgresql://root@cockroachdb:26257/identity_api_dev?sslmode=disable


### PR DESCRIPTION
I noticed a few missing bits when trying to make the devcontainer work in vscode along side other devcontainers:

* Add useful tooling to the devcontainer
* Update `devcontainer.json` for use in vscode with extensions, etc
* Change dev database from `defaultdb` to `identity_api_dev`
* Dont forward explicit ports from cockroach so they don't collide (internal to the devcontainer its still the default port)
