### PR TITLE
Chart version should determine image tag for the chart

### DIFF
--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -2,7 +2,6 @@
 image:
   repository: "ghcr.io/infratographer/identity-api"
   pullPolicy: IfNotPresent
-  tag: "latest"
 
 copyKeys:
   repository: "busybox"


### PR DESCRIPTION
This default had made the chart render out with the tag "latest" which isn't helpful with the pullPolicy of "IfNotPresent". Removing the tag in the values file lets the `.Chart.AppVersion` set the image tag instead.