### PR TITLE
Update Ingress template to match values schema

### DIFF
--- a/chart/identity-api/templates/ingress.yaml
+++ b/chart/identity-api/templates/ingress.yaml
@@ -22,15 +22,15 @@ spec:
     - host: {{ .host  | quote }}
       http:
         paths:
-          {{- range (.paths | default (list "/")) }}
-          - pathType: {{ $.Values.ingress.pathType | default "Prefix" | quote }}
-            path: {{ . | quote }}
+          {{- range .paths }}
+          - pathType: {{ .pathType | default "Prefix" | quote }}
+            path: {{ .path | quote }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   name: web
-  {{- end }}
+          {{- end }}
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls:

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -73,15 +73,10 @@ ingress:
   enabled: false
   annotations: {}
 
-  # ```yaml
-  # hosts:
-  #   - host: bar.foo
-  #     paths:
-  #       - /example
-  #```
+  # hosts is the list of hosts and path rules for this Ingress
   hosts: []
 
-  # tls is a list of hosts and secrets for an Ingres
+  # tls is a list of hosts and secrets for this Ingress
   # ```yaml
   # tls:
   #   - hosts:


### PR DESCRIPTION
The chart values schema for identity-api assumes Ingress paths have two keys: path and pathType. The template, however, assumes the paths list is a list of strings. This PR resolves this inconsistency by updating the Ingress template to use the values as defined in the chart values schema.