### PR TITLE
Format OAuth client URNs using x/urnx

### DIFF
--- a/internal/oauth2/flow_client_credentials.go
+++ b/internal/oauth2/flow_client_credentials.go
@@ -31,7 +31,7 @@ type clientCredentialsConfigurator interface {
 func buildClientURN(c fosite.Client) string {
 	clientUUID := uuid.MustParse(c.GetID())
 
-	urn, err := urnx.Build(types.URNNamespace, types.URNResourceTypeUser, clientUUID)
+	urn, err := urnx.Build(types.URNNamespace, types.URNResourceTypeClient, clientUUID)
 	if err != nil {
 		// If for some reason we aren't building valid URNs, panic
 		panic(err)

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -7,6 +7,6 @@ const (
 	// URNResourceTypeUser represents the user resource type in a URN.
 	URNResourceTypeUser = "user"
 
-	// URNResourceTypeUser represents the client resource type in a URN.
+	// URNResourceTypeClient represents the client resource type in a URN.
 	URNResourceTypeClient = "client"
 )

--- a/internal/types/const.go
+++ b/internal/types/const.go
@@ -6,4 +6,7 @@ const (
 
 	// URNResourceTypeUser represents the user resource type in a URN.
 	URNResourceTypeUser = "user"
+
+	// URNResourceTypeUser represents the client resource type in a URN.
+	URNResourceTypeClient = "client"
 )


### PR DESCRIPTION
For consistency, we should be formatting all resource URNs using the Infratographer x/urnx package. This commit updates the OAuth client_credentials grant handler to use the package when formatting client IDs as URNs.