### PR TITLE
Add imagePullSecrets to Helm chart

### DIFF
--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
     spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+      {{- with .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: copy-keys
           image: "{{ .Values.copyKeys.repository }}:{{ .Values.copyKeys.tag }}"

--- a/chart/identity-api/values.schema.json
+++ b/chart/identity-api/values.schema.json
@@ -47,6 +47,17 @@
             },
             "containerUserID": {
               "type": "integer"
+            },
+            "imagePullSecrets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
             }
           }
         },

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -13,6 +13,7 @@ deployment:
   extraLabels: {}
   annotations: {}
   resources: {}
+  imagePullSecrets: []
 
   containerUserID: 65532
 


### PR DESCRIPTION
Private image repositories generally require image pull secrets when deploying. This PR adds a chart value,
deployment.imagePullSecrets, that sets image pull secrets for the identity-api deployment.