### PR TITLE
add oidc discovery endpoint

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -102,7 +102,7 @@ func serve(_ context.Context) {
 		logger.Fatal("error initializing UserInfo handler: %s", err)
 	}
 
-	router := routes.NewRouter(logger, oauth2Config, provider)
+	router := routes.NewRouter(logger, oauth2Config, provider, config.Config.OAuth.Issuer)
 
 	emptyLogFn := func(c *gin.Context) []zapcore.Field {
 		return []zapcore.Field{}

--- a/internal/routes/oidc.go
+++ b/internal/routes/oidc.go
@@ -1,0 +1,79 @@
+package routes
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+type oidcHandler struct {
+	logger *zap.SugaredLogger
+	issuer string
+}
+
+type providerJSON struct {
+	Issuer      string `json:"issuer"`
+	AuthURL     string `json:"authorization_endpoint,omitempty"`
+	TokenURL    string `json:"token_endpoint"`
+	JWKSURL     string `json:"jwks_uri"`
+	UserInfoURL string `json:"userinfo_endpoint"`
+}
+
+// Handle processes the request for the OIDC handler.
+func (h *oidcHandler) Handle(ctx *gin.Context) {
+	out := providerJSON{
+		Issuer:      h.issuer,
+		TokenURL:    buildURL(ctx, "../../token").String(),
+		JWKSURL:     buildURL(ctx, "../../jwks.json").String(),
+		UserInfoURL: buildURL(ctx, "../../userinfo").String(),
+	}
+
+	ctx.JSON(http.StatusOK, out)
+}
+
+// buildURL returns a new *url.URL for the current page being requested, overwriting the values with the ones provided.
+//
+//nolint:cyclop // necessary complexity.
+func buildURL(c *gin.Context, path string) *url.URL {
+	outURL := new(url.URL)
+
+	if c != nil && c.Request != nil && c.Request.URL != nil {
+		outURL.Path = c.Request.URL.JoinPath(path).Path
+
+		// gin doesn't expose an easy way to check if the request came from a trusted proxy.
+		// However the ClientIP will return the source ip instead of the remote ip if coming from a trusted proxy.
+		// So we can compare the two, if they're the same, then we're either not behind a proxy or not behind a trusted proxy.
+		if c.ClientIP() != c.RemoteIP() {
+			if scheme := c.Request.Header.Get("X-Forwarded-Proto"); scheme != "" {
+				outURL.Scheme = scheme
+			}
+
+			if host := c.Request.Header.Get("X-Forwarded-Host"); host != "" {
+				outURL.Host = host
+			}
+		}
+
+		if outURL.Scheme == "" {
+			// Request.URL.Scheme is usually empty, however if it isn't we'll use that scheme.
+			// If empty, we'll check if TLS was used, and if so, set the scheme as https.
+			switch {
+			case c.Request.URL.Scheme != "":
+				outURL.Scheme = c.Request.URL.Scheme
+			case c.Request.TLS != nil:
+				outURL.Scheme = "https"
+			default:
+				outURL.Scheme = "http"
+			}
+		}
+
+		if outURL.Host == "" {
+			if host := c.Request.Host; host != "" {
+				outURL.Host = host
+			}
+		}
+	}
+
+	return outURL
+}

--- a/internal/routes/oidc_test.go
+++ b/internal/routes/oidc_test.go
@@ -1,0 +1,137 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		headers http.Header
+		request string
+		path    string
+		expect  string
+	}{
+		{
+			"missing request",
+			nil,
+			"",
+			"",
+			"",
+		},
+		{
+			"no path",
+			nil,
+			"http://test.local/path",
+			"",
+			"http://test.local/path",
+		},
+		{
+			"with path",
+			nil,
+			"http://test.local/path",
+			"to/test",
+			"http://test.local/path/to/test",
+		},
+		{
+			"with updir path",
+			nil,
+			"http://test.local/path",
+			"../to/test",
+			"http://test.local/to/test",
+		},
+		{
+			"with port",
+			nil,
+			"http://test.local:9191/path/to/random/endpoint",
+			"to/test",
+			"http://test.local:9191/path/to/random/endpoint/to/test",
+		},
+		{
+			"with path, alt hostname, trusted proxy",
+			http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Host":  []string{"test2.local"},
+				"X-Forwarded-Proto": []string{"schemetest"},
+			},
+			"http://test.local/path",
+			"to/test",
+			"schemetest://test2.local/path/to/test",
+		},
+		{
+			"with port, trusted proxy",
+			http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Proto": []string{"schemetest"},
+			},
+			"http://test.local:9191/path/to/random/endpoint",
+			"",
+			"schemetest://test.local:9191/path/to/random/endpoint",
+		},
+		{
+			"with path, alt hostname, untrusted proxy",
+			http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Host":  []string{"test2.local"},
+				"X-Forwarded-Proto": []string{"schemetest"},
+			},
+			"http://test.local/path",
+			"to/test",
+			"http://test.local/path/to/test",
+		},
+		{
+			"with port, untrusted proxy",
+			http.Header{
+				"X-Forwarded-For":   []string{"1.2.3.4"},
+				"X-Forwarded-Proto": []string{"schemetest"},
+			},
+			"http://test.local:9191/path/to/random/endpoint",
+			"",
+			"http://test.local:9191/path/to/random/endpoint",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ginCtx, ginEngine := gin.CreateTestContext(httptest.NewRecorder())
+
+			require.NoError(t, ginEngine.SetTrustedProxies([]string{"10.11.12.13"}))
+
+			if tc.request != "" {
+				ginCtx.Request = httptest.NewRequest("GET", tc.request, nil)
+
+				// Normal http requests don't have the scheme included
+				// https://stackoverflow.com/questions/40826664/get-scheme-of-the-current-request-url
+				ginCtx.Request.URL.Scheme = ""
+
+				ginCtx.Request.Header = tc.headers
+
+				ginCtx.Request.RemoteAddr = "1.2.3.4:1234"
+
+				if strings.HasSuffix(tc.name, "trusted proxy") && !strings.HasSuffix(tc.name, "untrusted proxy") {
+					ginCtx.Request.RemoteAddr = "10.11.12.13:4567"
+				}
+			}
+
+			result := buildURL(ginCtx, tc.path)
+
+			if tc.expect == "" {
+				require.Nil(t, result, "expected result to be nil")
+			} else {
+				assert.Equal(t, tc.expect, result.String(), "unexpected returned url")
+			}
+		})
+	}
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -14,14 +14,16 @@ type Router struct {
 	logger   *zap.SugaredLogger
 	provider fosite.OAuth2Provider
 	config   fositex.OAuth2Configurator
+	issuer   string
 }
 
 // NewRouter creates a new Router.
-func NewRouter(logger *zap.SugaredLogger, config fositex.OAuth2Configurator, provider fosite.OAuth2Provider) *Router {
+func NewRouter(logger *zap.SugaredLogger, config fositex.OAuth2Configurator, provider fosite.OAuth2Provider, issuer string) *Router {
 	return &Router{
 		logger:   logger,
 		provider: provider,
 		config:   config,
+		issuer:   issuer,
 	}
 }
 
@@ -35,7 +37,12 @@ func (r *Router) Routes(rg *gin.RouterGroup) {
 		logger: r.logger,
 		config: r.config,
 	}
+	oidc := &oidcHandler{
+		logger: r.logger,
+		issuer: r.issuer,
+	}
 
 	rg.POST("/token", tok.Handle)
 	rg.GET("/jwks.json", jwks.Handle)
+	rg.GET("/.well-known/openid-configuration", oidc.Handle)
 }


### PR DESCRIPTION
Adds /.well-known/openid-configuration endpoint.

Issuer is provided from the config.OIDC.Issuer field.

The remaining fields are generated from the http request.

Resolves #105 