### PR TITLE
oidc use issuer as base instead of current request

### DIFF
--- a/internal/routes/oidc.go
+++ b/internal/routes/oidc.go
@@ -1,7 +1,6 @@
 package routes
 
 import (
-	"net"
 	"net/http"
 	"net/url"
 
@@ -24,63 +23,17 @@ type providerJSON struct {
 
 // Handle processes the request for the OIDC handler.
 func (h *oidcHandler) Handle(ctx echo.Context) error {
+	issuer, err := url.Parse(h.issuer)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "bad issuer").SetInternal(err)
+	}
+
 	out := providerJSON{
 		Issuer:      h.issuer,
-		TokenURL:    buildURL(ctx, "../../token").String(),
-		JWKSURL:     buildURL(ctx, "../../jwks.json").String(),
-		UserInfoURL: buildURL(ctx, "../../userinfo").String(),
+		TokenURL:    issuer.JoinPath("/token").String(),
+		JWKSURL:     issuer.JoinPath("/jwks.json").String(),
+		UserInfoURL: issuer.JoinPath("/userinfo").String(),
 	}
 
 	return ctx.JSON(http.StatusOK, out)
-}
-
-// buildURL returns a new *url.URL for the current page being requested, overwriting the values with the ones provided.
-//
-//nolint:cyclop // necessary complexity.
-func buildURL(c echo.Context, path string) *url.URL {
-	if c == nil || c.Request() == nil || c.Request().URL == nil {
-		return nil
-	}
-
-	request := c.Request()
-
-	outURL := &url.URL{
-		Path: request.URL.JoinPath(path).Path,
-	}
-
-	remoteAddr, _, _ := net.SplitHostPort(request.RemoteAddr) //nolint:errcheck // we'll just use the empty string if an error occurs.
-
-	// echo doesn't expose an easy way to check if the request came from a trusted proxy.
-	// However the RealIP will return the source ip instead of the remote ip if coming from a trusted proxy.
-	// So we can compare the two, if they're the same, then we're either not behind a proxy or not behind a trusted proxy.
-	if c.RealIP() != remoteAddr {
-		if scheme := request.Header.Get("X-Forwarded-Proto"); scheme != "" {
-			outURL.Scheme = scheme
-		}
-
-		if host := request.Header.Get("X-Forwarded-Host"); host != "" {
-			outURL.Host = host
-		}
-	}
-
-	if outURL.Scheme == "" {
-		// Request.URL.Scheme is usually empty, however if it isn't we'll use that scheme.
-		// If empty, we'll check if TLS was used, and if so, set the scheme as https.
-		switch {
-		case request.URL.Scheme != "":
-			outURL.Scheme = request.URL.Scheme
-		case request.TLS != nil:
-			outURL.Scheme = "https"
-		default:
-			outURL.Scheme = "http"
-		}
-	}
-
-	if outURL.Host == "" {
-		if host := request.Host; host != "" {
-			outURL.Host = host
-		}
-	}
-
-	return outURL
 }


### PR DESCRIPTION
Use the issuer as the base url instead of generating a relative url based on the current request to ensure the url is rendered properly.