### PR TITLE
chart migrateOnInit: override args instead of command

### DIFF
--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -63,8 +63,7 @@ spec:
                 name: "{{ .Values.config.storage.crdb.uriSecretName }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
-          command:
-            - /app/identity-api
+          args:
             - migrate
           {{- with .Values.deployment.resources }}
           resources:


### PR DESCRIPTION
Overrides the args instead of command when running migrations.