### PR TITLE
add empty graphql schema to satisfy releases

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,0 +1,3 @@
+"""
+TODO: Add generated schema.
+"""


### PR DESCRIPTION
GoReleaser release pipeline expects a schema.graphql file. Although Identity-API has yet to have graphql added, this empty file should satisfy the release pipeline to allow releases to be done.

This file will be replaced in the future by a proper generated schema once graphql has been added to the repo.