### PR TITLE
Parse ID token-like claims instead of fetching them

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -184,9 +184,8 @@ type UserInfoService interface {
 	// StoreUserInfo stores the userInfo into the storage backend.
 	StoreUserInfo(ctx context.Context, userInfo UserInfo) (UserInfo, error)
 
-	// FetchUserInfoFromIssuer uses the rawToken to make a userinfo endpoint request
-	// and unpacks it into the UserInfo type.
-	FetchUserInfoFromIssuer(ctx context.Context, iss, rawToken string) (UserInfo, error)
+	// ParseUserInfoFromClaims parses OIDC ID token claims from the given claim map.
+	ParseUserInfoFromClaims(claims map[string]any) (UserInfo, error)
 }
 
 // OAuthClientManager defines the storage interface for OAuth clients.


### PR DESCRIPTION
As it turns out, certain OIDC providers only provide opaque access tokens by default (e.g., Okta) and others only provide ID tokens (e.g., GitHub Actions). Given this, it makes more sense to try and parse ID token-like claims from the token we get directly instead of reaching out to a service we may not be able to even access with the given token. This PR removes UserInfo requests entirely and replaces that logic with token claim parsing instead.