### PR TITLE
Make subject ID generation deterministic

### DIFF
--- a/internal/storage/userinfo_test.go
+++ b/internal/storage/userinfo_test.go
@@ -64,6 +64,11 @@ func TestUserInfoStore(t *testing.T) {
 		Subject: "sub0|malikadmin",
 	}
 
+	// This user ID should be deterministically generated, so we precompute it here rather
+	// than use generateSubjectID
+	expUserInfoID, err := gidx.Parse("idntusr-JJ5-CXOzTNil-ncNcX8U")
+	require.NoError(t, err)
+
 	var userInfoStored types.UserInfo
 
 	// seed the DB
@@ -166,7 +171,7 @@ func TestUserInfoStore(t *testing.T) {
 		cases := []testingx.TestCase[gidx.PrefixedID, types.UserInfo]{
 			{
 				Name:    "Success",
-				Input:   userInfoStored.ID,
+				Input:   expUserInfoID,
 				SetupFn: setupFn,
 				CheckFn: func(ctx context.Context, t *testing.T, res testingx.TestResult[types.UserInfo]) {
 					assert.NoError(t, res.Err)


### PR DESCRIPTION
There are a number of use cases where it is advantageous to make the value of the "sub" claim in identity-api access tokens deterministic. This commit updates the token format design document with a deterministic algorithm for subject ID generation based on the subject token "iss" and "sub" claim values, and additionally updates identity-api to implement this algorithm and use it during token exchange.

Fixes #166.