### PR TITLE
remove redefine of jwks resulting in only one key to be stored

### DIFF
--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -126,8 +126,6 @@ func parsePrivateKeys(keys []PrivateKey) (*jose.JSONWebKey, *jose.JSONWebKeySet,
 			return nil, nil, err
 		}
 
-		var jwks jose.JSONWebKeySet
-
 		jwks.Keys = append(jwks.Keys, jwk)
 	}
 


### PR DESCRIPTION
jwks variable was being redefined resulting in additional keys not being appended to the jwks being returned.