### PR TITLE
Add OTLP support to Helm chart

### DIFF
--- a/chart/identity-api/templates/configMap.yaml
+++ b/chart/identity-api/templates/configMap.yaml
@@ -19,6 +19,9 @@ data:
       provider: {{ .otel.provider }}
       stdout:
         prettyPrint: {{ .otel.stdout.prettyPrint }}
+      otlp:
+        endpoint: {{ .otel.otlp.endpoint }}
+        insecure: {{ .otel.otlp.insecure }}
       {{- end }}
     oauth:
       issuer: {{ .oauth.issuer | quote}}

--- a/chart/identity-api/values.schema.json
+++ b/chart/identity-api/values.schema.json
@@ -91,6 +91,17 @@
                       "type": "boolean"
                     }
                   }
+                },
+                "otlp": {
+                  "type": "object",
+                  "properties": {
+                    "endpoint": {
+                      "type": "string"
+                    },
+                    "insecure": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },


### PR DESCRIPTION
The Helm chart is currently missing support for configuring OTLP-based tracing. This PR adds it to the chart.