### PR TITLE
Add instrumentation to Client Credentials grant

### DIFF
--- a/internal/oauth2/flow_client_credentials.go
+++ b/internal/oauth2/flow_client_credentials.go
@@ -44,6 +44,7 @@ func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.C
 	ctx, span := c.tracer.Start(ctx, "HandleTokenEndpointRequest")
 
 	defer span.End()
+
 	client := request.GetClient()
 
 	span.SetAttributes(


### PR DESCRIPTION
This commit adds OpenTelemetry instrumentation to the OAuth 2.0 Client Credentials grant in identity-api.