### PR TITLE
Add auditing to identity-api

### DIFF
--- a/internal/auditx/config.go
+++ b/internal/auditx/config.go
@@ -1,0 +1,24 @@
+package auditx
+
+import (
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"go.infratographer.com/x/viperx"
+)
+
+// Config represents an audit middleware configuration.
+type Config struct {
+	Enabled   bool
+	Path      string
+	Component string
+}
+
+// MustViperFlags sets the flags needed for auditing to work.
+func MustViperFlags(v *viper.Viper, flags *pflag.FlagSet) {
+	flags.Bool("audit-enabled", false, "enable auditing")
+	viperx.MustBindFlag(v, "audit.enabled", flags.Lookup("audit-enabled"))
+	flags.String("audit-path", "", "audit log path")
+	viperx.MustBindFlag(v, "audit.path", flags.Lookup("audit-path"))
+	flags.String("audit-component", "", "audit component")
+	viperx.MustBindFlag(v, "audit.component", flags.Lookup("audit-component"))
+}

--- a/internal/auditx/doc.go
+++ b/internal/auditx/doc.go
@@ -1,0 +1,2 @@
+// Package auditx provides functions and data for wrapping echoaudit and performing audit logging.
+package auditx

--- a/internal/auditx/middleware.go
+++ b/internal/auditx/middleware.go
@@ -55,6 +55,7 @@ func newNopMiddleware() (*echoaudit.Middleware, func() error, error) {
 	return mdw, closer, nil
 }
 
+// NewMiddleware creates a new echoaudit middleware with closer function based on the given config.
 func NewMiddleware(ctx context.Context, c Config) (*echoaudit.Middleware, func() error, error) {
 	if !c.Enabled {
 		return newNopMiddleware()

--- a/internal/auditx/middleware.go
+++ b/internal/auditx/middleware.go
@@ -1,0 +1,78 @@
+// Package auditx provides functions and data for auditing OAuth 2.0-specific events.
+package auditx
+
+import (
+	"context"
+	"io"
+
+	"github.com/labstack/echo/v4"
+	audithelpers "github.com/metal-toolbox/auditevent/helpers"
+	"github.com/metal-toolbox/auditevent/middleware/echoaudit"
+)
+
+const (
+	ctxKeyOutcome = "auditx.outcome"
+	ctxKeySubject = "auditx.subject"
+)
+
+// SetSubject sets the subject of the auditable event.
+func SetSubject(c echo.Context, subject map[string]string) {
+	c.Set(ctxKeySubject, subject)
+}
+
+func getSubject(c echo.Context) map[string]string {
+	maybeSubject := c.Get(ctxKeySubject)
+
+	if maybeSubject == nil {
+		return nil
+	}
+
+	return maybeSubject.(map[string]string)
+}
+
+// SetOutcome sets the outcome of the auditable event.
+func SetOutcome(c echo.Context, outcome string) {
+	c.Set(ctxKeyOutcome, outcome)
+}
+
+func getOutcome(c echo.Context) string {
+	outcome := c.Get(ctxKeyOutcome)
+
+	if outcome == nil {
+		return echoaudit.GetOutcomeDefault(c)
+	}
+
+	return outcome.(string)
+}
+
+func newNopMiddleware() (*echoaudit.Middleware, func() error, error) {
+	mdw := echoaudit.NewJSONMiddleware("", io.Discard)
+
+	closer := func() error {
+		return nil
+	}
+
+	return mdw, closer, nil
+}
+
+func NewMiddleware(ctx context.Context, c Config) (*echoaudit.Middleware, func() error, error) {
+	if !c.Enabled {
+		return newNopMiddleware()
+	}
+
+	f, err := audithelpers.OpenAuditLogFileUntilSuccessWithContext(ctx, c.Path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	closer := func() error {
+		return f.Close()
+	}
+
+	mdw := echoaudit.NewJSONMiddleware(c.Component, f).
+		WithPrometheusMetrics().
+		WithSubjectHandler(getSubject).
+		WithOutcomeHandler(getOutcome)
+
+	return mdw, closer, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"go.infratographer.com/x/loggingx"
 	"go.infratographer.com/x/otelx"
 
+	"go.infratographer.com/identity-api/internal/auditx"
 	"go.infratographer.com/identity-api/internal/fositex"
 )
 
@@ -17,4 +18,5 @@ var Config struct {
 	OAuth   fositex.Config
 	OTel    otelx.Config
 	CRDB    crdbx.Config
+	Audit   auditx.Config
 }

--- a/internal/routes/exchange.go
+++ b/internal/routes/exchange.go
@@ -1,15 +1,55 @@
 package routes
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/labstack/echo/v4"
+	"github.com/metal-toolbox/auditevent"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
+	"go.infratographer.com/identity-api/internal/auditx"
+	"go.infratographer.com/identity-api/internal/types"
 	"go.uber.org/zap"
 )
 
 type tokenHandler struct {
 	logger   *zap.SugaredLogger
 	provider fosite.OAuth2Provider
+}
+
+func getOutcomeFromError(c echo.Context, err error) string {
+	rfcErr := fosite.ErrorToRFC6749Error(err)
+
+	if rfcErr == nil {
+		return auditevent.OutcomeFailed
+	}
+
+	status := rfcErr.StatusCode()
+
+	if status >= http.StatusBadRequest && status < http.StatusInternalServerError {
+		return auditevent.OutcomeDenied
+	}
+
+	if status >= http.StatusInternalServerError {
+		return auditevent.OutcomeFailed
+	}
+
+	return auditevent.OutcomeSucceeded
+}
+
+func setContextFromError(c echo.Context, err error) {
+	outcome := getOutcomeFromError(c, err)
+
+	auditx.SetOutcome(c, outcome)
+
+	var tokErr types.ErrorInvalidTokenRequest
+
+	if !errors.As(err, &tokErr) {
+		return
+	}
+
+	auditx.SetSubject(c, tokErr.Subject)
 }
 
 // Handle processes the request for the token handler.
@@ -19,16 +59,21 @@ func (h *tokenHandler) Handle(c echo.Context) error {
 	ctx := c.Request().Context()
 
 	accessRequest, err := h.provider.NewAccessRequest(ctx, c.Request(), &session)
+
 	if err != nil {
+		setContextFromError(c, err)
+
 		h.logger.Errorf("Error occurred in NewAccessRequest: %+v", err)
 		h.provider.WriteAccessError(ctx, c.Response().Writer, accessRequest, err)
 
 		return nil
 	}
 
-	// set auditing fields from the session
-	c.Set("jwt.subject", session.GetSubject())
-	c.Set("jwt.user", session.GetUsername())
+	subject := map[string]string{
+		"subject": session.JWTClaims.Subject,
+	}
+
+	auditx.SetSubject(c, subject)
 
 	response, err := h.provider.NewAccessResponse(ctx, accessRequest)
 	if err != nil {

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -1,6 +1,9 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrorIssuerNotFound represents an error condition where an issuer was not found.
@@ -20,3 +23,12 @@ var (
 	// ErrOAuthClientNotFound is returned if the OAuthClient doesn't exist.
 	ErrOAuthClientNotFound = errors.New("oauth client does not exist")
 )
+
+// ErrorInvalidTokenRequest represents an error where an access token request failed.
+type ErrorInvalidTokenRequest struct {
+	Subject map[string]string
+}
+
+func (e ErrorInvalidTokenRequest) Error() string {
+	return fmt.Sprintf("invalid access request for subject %v", e.Subject)
+}


### PR DESCRIPTION
This PR adds proper audit logging to identity-api for token exchange and client credentials token requests, as well as API requests.