### PR TITLE
Add support for auditing to the Helm chart

### DIFF
--- a/chart/identity-api/templates/configMap.yaml
+++ b/chart/identity-api/templates/configMap.yaml
@@ -36,4 +36,8 @@ data:
         {{- end }}
     storage:
       type: crdb
+    audit:
+      enabled: {{ .audit.enabled }}
+      path: /app-audit/audit.log
+      component: {{ .audit.component }}
   {{- end }}

--- a/chart/identity-api/templates/deployment.yaml
+++ b/chart/identity-api/templates/deployment.yaml
@@ -76,6 +76,17 @@ spec:
               mountPath: "{{ .Values.config.storage.crdb.certMountPath }}"
           {{- end }}
         {{- end }}
+        {{- if .Values.config.audit.enabled }}
+        - image: ghcr.io/metal-toolbox/audittail:v0.8.0
+          args:
+            - 'init'
+            - '-f'
+            - '/app-audit/audit.log'
+          name: init-audit-logs
+          volumeMounts:
+            - mountPath: /app-audit
+              name: audit-logs
+        {{- end }}
       containers:
         - name: {{ include "common.names.name" . }}
           envFrom:
@@ -85,11 +96,6 @@ spec:
             - secretRef:
                 name: "{{ . }}"
             {{- end }}
-          {{- with .Values.config.auditLogPath }}
-          env:
-            - name: IDAPI_AUDIT_LOG_PATH
-              value: "{{ . }}"
-          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
           volumeMounts:
@@ -101,6 +107,10 @@ spec:
           {{- if .Values.config.storage.crdb.caSecretName }}
             - name: crdb-ca
               mountPath: "{{ .Values.config.storage.crdb.certMountPath }}"
+          {{- end }}
+          {{- if .Values.config.audit.enabled }}
+            - name: audit-logs
+              mountPath: /app-audit
           {{- end }}
           ports:
             - name: web
@@ -121,6 +131,17 @@ spec:
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.config.audit.enabled }}
+        - image: ghcr.io/metal-toolbox/audittail:v0.8.0
+          args:
+            - '-f'
+            - '/app-audit/audit.log'
+          name: audit-logger
+          volumeMounts:
+            - mountPath: /app-audit
+              name: audit-logs
+              readOnly: true
+        {{- end }}
       volumes:
         - name: signing-keys-seed
           secret:
@@ -135,4 +156,8 @@ spec:
         - name: crdb-ca
           secret:
             secretName: "{{ . }}"
+        {{- end }}
+        {{- if .Values.config.audit.enabled }}
+        - name: audit-logs
+          emptyDir: {}
         {{- end }}

--- a/chart/identity-api/values.schema.json
+++ b/chart/identity-api/values.schema.json
@@ -154,6 +154,17 @@
                   }
                 }
               }
+            },
+            "audit": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "component": {
+                  "type": "string"
+                }
+              }
             }
           }
         },

--- a/chart/identity-api/values.yaml
+++ b/chart/identity-api/values.yaml
@@ -76,7 +76,9 @@ config:
           path: "/keys/default.pem"
           algorithm: RS256
 
-  auditLogPath: /app-audit/audit.log
+  audit:
+    enabled: false
+    component: identity-api
 
 ingress:
   enabled: false


### PR DESCRIPTION
This PR adds support for audit logging to the identity-api Helm chart using audittail. The path itself is hardcoded in the chart since there isn't really a compelling reason for someone to choose a different path for writing audit events.