### PR TITLE
upgrade go-jose to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/cockroachdb/cockroach-go/v2 v2.3.6
 	github.com/deepmap/oapi-codegen v1.16.2
 	github.com/getkin/kin-openapi v0.123.0
+	github.com/go-jose/go-jose/v3 v3.0.1
 	github.com/google/cel-go v0.20.0
 	github.com/labstack/echo-jwt/v4 v4.2.0
 	github.com/labstack/echo/v4 v4.11.4
@@ -26,7 +27,6 @@ require (
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20240304161311-37d4d3c04a78
 	google.golang.org/protobuf v1.32.0
-	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -63,7 +63,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/gin-gonic/gin v1.9.1 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -730,7 +730,6 @@ gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec/go.mod h1:a
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
-gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/fositex/config.go
+++ b/internal/fositex/config.go
@@ -3,12 +3,12 @@ package fositex
 import (
 	"context"
 
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.infratographer.com/x/viperx"
-	"gopkg.in/square/go-jose.v2"
 
 	"go.infratographer.com/identity-api/internal/types"
 )

--- a/internal/fositex/fosite.go
+++ b/internal/fositex/fosite.go
@@ -15,10 +15,10 @@ import (
 	"os"
 	"time"
 
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/ory/fosite"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"gopkg.in/square/go-jose.v2"
 )
 
 const instrumentationName = "go.infratographer.com/identity-api/internal/fositex"

--- a/internal/routes/jwks.go
+++ b/internal/routes/jwks.go
@@ -3,9 +3,9 @@ package routes
 import (
 	"net/http"
 
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/labstack/echo/v4"
 	"go.uber.org/zap"
-	"gopkg.in/square/go-jose.v2"
 
 	"go.infratographer.com/identity-api/internal/fositex"
 )


### PR DESCRIPTION
fosite v0.45 moved to github.com/go-jose/go-jose/v3 This brings us back in line with fosite.