### PR TITLE
add endpoint for retrieving a user's info by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If the permissions config has been defined, the actor will need access to the fo
 * iam_oauthclient_create
 * iam_oauthclient_delete
 * iam_oauthclient_get
+* iam_user_get
 
 [pkcs8]: https://en.wikipedia.org/wiki/PKCS_8
 [permissionsapi]: https://github.com/infratographer/permissions-api

--- a/internal/api/httpsrv/handle_user.go
+++ b/internal/api/httpsrv/handle_user.go
@@ -1,0 +1,51 @@
+package httpsrv
+
+import (
+	"context"
+	"net/http"
+
+	"go.infratographer.com/identity-api/internal/types"
+	"go.infratographer.com/permissions-api/pkg/permissions"
+)
+
+const (
+	actionUserGet = "iam_user_get"
+)
+
+func (h *apiHandler) GetUserByID(ctx context.Context, req GetUserByIDRequestObject) (GetUserByIDResponseObject, error) {
+	// Find the owner the user's issuer is on to check permissions.
+	ownerID, err := h.engine.LookupUserOwnerID(ctx, req.UserID)
+	switch err {
+	case nil:
+	case types.ErrUserInfoNotFound:
+		return nil, errorWithStatus{
+			status:  http.StatusNotFound,
+			message: err.Error(),
+		}
+	default:
+		return nil, err
+	}
+
+	if err := permissions.CheckAccess(ctx, ownerID, actionUserGet); err != nil {
+		return nil, permissionsError(err)
+	}
+
+	info, err := h.engine.LookupUserInfoByID(ctx, req.UserID)
+	switch err {
+	case nil:
+	case types.ErrUserInfoNotFound:
+		return nil, errorWithStatus{
+			status:  http.StatusNotFound,
+			message: err.Error(),
+		}
+	default:
+		return nil, err
+	}
+
+	out, err := info.ToV1User()
+	if err != nil {
+		return nil, err
+	}
+
+	return GetUserByID200JSONResponse(out), nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -172,6 +172,32 @@ type UserInfo struct {
 	Subject string          `json:"sub"`
 }
 
+// ToV1User converts an user info to an API user info.
+func (u UserInfo) ToV1User() (v1.User, error) {
+	var (
+		name  *string
+		email *string
+	)
+
+	if u.Name != "" {
+		name = &u.Name
+	}
+
+	if u.Email != "" {
+		email = &u.Email
+	}
+
+	out := v1.User{
+		ID:      u.ID,
+		Name:    name,
+		Email:   email,
+		Issuer:  u.Issuer,
+		Subject: u.Subject,
+	}
+
+	return out, nil
+}
+
 // UserInfoService defines the storage class for storing User
 // information related to the subject tokens.
 type UserInfoService interface {
@@ -180,6 +206,9 @@ type UserInfoService interface {
 
 	// LookupUserInfoByID returns the user info for a STS user ID
 	LookupUserInfoByID(ctx context.Context, id gidx.PrefixedID) (UserInfo, error)
+
+	// LookupUserOwnerID finds the Owner ID of the Issuer for the given User ID.
+	LookupUserOwnerID(ctx context.Context, id gidx.PrefixedID) (gidx.PrefixedID, error)
 
 	// StoreUserInfo stores the userInfo into the storage backend.
 	StoreUserInfo(ctx context.Context, userInfo UserInfo) (UserInfo, error)

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -174,6 +174,28 @@ paths:
               schema:
                 $ref: '#/components/schemas/DeleteResponse'
 
+  /api/v1/users/{userID}:
+    get:
+      tags:
+        - Users
+      summary: Gets information about a User.
+      operationId: getUserByID
+      parameters:
+        - in: path
+          name: userID
+          required: true
+          description: User ID
+          schema:
+            type: string
+            x-go-type: gidx.PrefixedID
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
 components:
   schemas:
     DeleteResponse:
@@ -291,3 +313,29 @@ components:
           items:
             type: string
           description: Grantable audiences
+
+    User:
+      required:
+        - id
+        - iss
+        - sub
+      properties:
+        id:
+          x-go-name: ID
+          type: string
+          x-go-type: gidx.PrefixedID
+          description: OAuth 2.0 User ID
+        name:
+          type: string
+          description: Name of the user
+        email:
+          type: string
+          description: Email of the user
+        iss:
+          x-go-name: Issuer
+          type: string
+          description: OAuth 2.0 Issuer of the user
+        sub:
+          x-go-name: Subject
+          type: string
+          description: OAuth 2.0 Subject for the user

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -94,6 +94,24 @@ type OAuthClient struct {
 	Secret *string `json:"secret,omitempty"`
 }
 
+// User defines model for User.
+type User struct {
+	// Email Email of the user
+	Email *string `json:"email,omitempty"`
+
+	// Id OAuth 2.0 User ID
+	ID gidx.PrefixedID `json:"id"`
+
+	// Iss OAuth 2.0 Issuer of the user
+	Issuer string `json:"iss"`
+
+	// Name Name of the user
+	Name *string `json:"name,omitempty"`
+
+	// Sub OAuth 2.0 Subject for the user
+	Subject string `json:"sub"`
+}
+
 // UpdateIssuerJSONRequestBody defines body for UpdateIssuer for application/json ContentType.
 type UpdateIssuerJSONRequestBody = IssuerUpdate
 
@@ -106,24 +124,26 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYX2/bNhD/KgduDxug2G775rc0HgJ1KxbECfqQBgVNne1LJVIjKSeGoe8+kJRi2ZLt",
-	"2R2Kpu1TKOp0/36/+xOvmFBZriRKa9hwxYyYY8b98UIjtxgbU6B2z7lWOWpL6N+KlFP2KeN5TnLmb3iS",
-	"kCUleXq1IWmXObIhM1aTnLEyYgkaoSl3smzILv74C/Ap12gMKWmgUglWfUYJ3owBq0DZOerqmUW1VjV5",
-	"QGGd1ofHz+ZTocmZ3LTw7sOfY7i9jtdfVb5E7Olsps4kz7ASc1JlxMLNtp5zmBcZl2caecInKYITg6nS",
-	"YOcIFBIVtePtdOr2Ot76tAfvC2Mh41bM/fVHRsZ8ZCFmWPC0QCAJJIXKXIbefbgxB2Ly8ZQR0/hPQRoT",
-	"NrwLwQWvGlm7L6MK8b/PCzu/SAmlbcPOi4RQiq7sVG8M2Dm3YOdkQHgtILgE5wEayyJGFrNuYlQXXGu+",
-	"PBWGYLINQ1cSXMwjTNHiNZpcSYPtgE0hBBrT4Ub6yJcGrC6wtzY3USpFLlv2ajXO5IspKUraYccjUNN9",
-	"hN8kYDyqLyqpGSVPvSuNU3rCJB79rNwjKpcSFu0o32ibPWui3eYJt/izg79kHpQRO7EtX2ourY+1ljFH",
-	"9eCuHuBdgde9AQR/wFf5l7aBbshG6yfXeC52tPeIGRQa7Q5nG76Og9yhAdGstefs3nskSE5V284YRaHJ",
-	"LuHG036MekEC4bfxzfh3eM8ln2Hm7J9fxUAGuPQnR6DMvXR0GN+MQSg5pVmhuVNr/GQhm+JuA5uqWcQW",
-	"qE1wadAb9F653KgcJc+JDdmb3qD3hkUs53buCdDnOfUXr/phbpr+KhziURlCdNPRnRzbvE9x4lFx901K",
-	"OpWaZ2hRGza866aMaNCF3LVzo87zkNWmWRMKN2Cjai9tM/YAq8p7pyrMdh/u68HA9z4lbVVIPM9TEj60",
-	"/oNxzq4a1n7VOGVD9kt/vSb3qx25v7U6eG5scSJM/WmRQkMsYqbIMq6Xz4n0dAgpWhOcu6Z816z70NVn",
-	"geWbgFyi/cHRaIZ/EhSXaA242taZtw98ogq7RmbdQ3q74Smj54oKM8H0V5T8h1qK6+GzF7iwfQXNbqRW",
-	"Ojvx8x3su6sjfbCOquw8kg1DeEYLlBCPmqiFbO+vpyDzdukr4ChUZn6+vGRIKjaeBIWvozUOk+We3Odu",
-	"VWpnP6ysp5VEEdbdr5R//0/tW5Us/+fUV0t7ubmWOIfLbxT24HED+W7MGw1SPUrfH/3feFTWO4hfb5Xp",
-	"qMr2DxSHBp1T7ViRa7Ugtxb5lrAx/wqZeJZ18KXy7NsnTTsxX5k5Xzx9QwSNRUgcMWpbTKpm7yEmHdNh",
-	"VE0l4T+tOw7J74I6zcp/Gf2mQZi9/aYs/w0AAP//PiWS5+QWAAA=",
+	"H4sIAAAAAAAC/+xYTW/bOBD9KwR3D7uAYrntzbc0LgJ1t7tBnKCHNChoaWwzlUgth3JiGPrviyGlSLZk",
+	"O0mDoml7sk1TnI83781Qax7rLNcKlEU+WnOMF5AJ9/XEgLAQIRZg6HdudA7GSnD/xqmQ2edM5LlUc7ci",
+	"kkRaqZVIzzZ22lUOfMTRGqnmvAx4AhgbmdNePuIn7/5mcJcbQJRaIauOZFZ/AcWcGWRWM20XYKrfPKhP",
+	"1dMbiC2denP7BT8XRpLJTQvvP/41YZfnUfNU5UvA747m+kiJDKpttKsMuF/ZPueYLYpMqCMDIhHTFBht",
+	"YzNtmF0Akz5RQTfeXqcuz6OtRwfsQ4GWZcLGC7f8iUvET9zHzJYiLYBJxaSKdUYZev/xAg/E5OIpA27g",
+	"v0IaSPjoygfnvWpl7boMKsT/PS7s4iSVoGwXdlEkElTcl53qH2R2ISyzC4ksdqewWChGHgBaHnBpIesv",
+	"jGpBGCNWT4XBm+zC0JcEinkMKVg4B8y1QugGjEUcA2KPG+mtWCGzpoBBY26qdQpCdezVx5DJF0MpmXTD",
+	"jsZMz/YV/GYBRuN6odo1l8nd4MzATN5BEo1/MfcRzJUJD3bQN9iunqbQLvNEWPil4C+5DsqAP1GWT41Q",
+	"1sVa78FHaXCfBjhX2OvBkHl/mGP518pAP2Tj5hcJz8kOeQ84QmzA7nC25evE7zvUINpcu88ukeoS+7Qb",
+	"MiHTrvF3tFwLZoH91bU/xWTveRIs+9pYY8irxV5nt2x6vuyE7h8i14HYsZju82lSOHW459kDvKoe6QeU",
+	"UuCNXjtSSTXTXfsTiAsj7YpdOAWbgFnKGNgfk4vJn+yDUGIOGZXS8VnEJDKh3DfyMaM/idmTiwmLtZrJ",
+	"eWEEHYtuSJA2hd0GNo/mAV+CQe/ScDAcvKKE6RyUyCUf8TeD4eAND3gu7MIBG4pchstXoR+BMFz7L9G4",
+	"9CHSoEPfqG6dT1HiCEbrbXWhI43IwIJBPrrqRyduMV/SMrlRU2bEa9O8DQLNSkF1xeiKz4H6La/pKD+m",
+	"uXBfD4eujWllK00UeZ7K2IUW3iA5u25Z+93AjI/4b2Fz4wmr6064NQW62tiqCT/AzYqUtbZRLWWZMKv7",
+	"RLpy8ClqtEpQf71qS7hv0HMvWJuAnIL9ydFoh/8kKE7BIiNum8zZZ2KqC9sg07SDwW54yuCeUb69Y7iW",
+	"yQO4FNVzxF7g/CDtT6bpqDqzFz+nXT8cj8xBHlXZuZXWz1NzuQTFonEbNZ/t/Xzye96uHAMehcrcjQov",
+	"GZK6Sz8FCsejBofpak/uc5p6u9n3t4+nUaLwN5dvlH/3fuKtTlbPnPrq/lVuDiTkcPmdwu49biHfj3lL",
+	"IPWtcvroPqNxWc8gblDW2MPK7rumQ42OjqaqyI1eShqLnCRs9L9CJa7Keuql8uz7L5puYr5x5Xx19/UR",
+	"tAah+BGttlNJVe89VEmPURhdl1LsHq0VR6ofonTazH8ZetMqmAfqDd0DMVzTR3W92dX66fr8kMbfXLN7",
+	"KsDbeSEN372geNax2b2DaGNCvx0iZfl/AAAA//9Kt5giQRoAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
This adds an http endpoint `/api/v1/users/{userID}` for retrieving a users information by the user's ID.

Permission is checked by checking the user issuer's owner ID for iam_user_get action.