### PR TITLE
parse jwkset correctly

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -172,7 +172,7 @@ func getAuthMiddleware(ctx context.Context, config fositex.OAuth2Configurator, s
 		return nil, err
 	}
 
-	jwks, err := keyfunc.NewJWKJSON(json.RawMessage(buff.Bytes()))
+	jwks, err := keyfunc.NewJWKSetJSON(json.RawMessage(buff.Bytes()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This corrects the v2 -> v3 keyfunc update to parse a jwkset instead of a single jwk.