### PR TITLE
Support list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ If the permissions config has been defined, the actor will need access to the fo
 * iam_issuer_update
 * iam_issuer_delete
 * iam_issuer_get
+* iam_issuer_list
 * iam_oauthclient_create
 * iam_oauthclient_delete
 * iam_oauthclient_get
+* iam_oauthclient_list
 * iam_user_get
 
 [pkcs8]: https://en.wikipedia.org/wiki/PKCS_8

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -97,7 +97,7 @@ func (h *apiHandler) GetIssuerByID(ctx context.Context, req GetIssuerByIDRequest
 	return GetIssuerByID200JSONResponse(out), nil
 }
 
-func (h *apiHandler) GetOwnerIssuers(ctx context.Context, req GetOwnerIssuersRequestObject) (GetOwnerIssuersResponseObject, error) {
+func (h *apiHandler) ListOwnerIssuers(ctx context.Context, req ListOwnerIssuersRequestObject) (ListOwnerIssuersResponseObject, error) {
 	if err := permissions.CheckAccess(ctx, req.OwnerID, actionIssuerList); err != nil {
 		return nil, permissionsError(err)
 	}
@@ -123,7 +123,7 @@ func (h *apiHandler) GetOwnerIssuers(ctx context.Context, req GetOwnerIssuersReq
 
 	out := IssuerCollectionJSONResponse(collection)
 
-	return GetOwnerIssuers200JSONResponse{out}, nil
+	return ListOwnerIssuers200JSONResponse{out}, nil
 }
 
 func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestObject) (UpdateIssuerResponseObject, error) {

--- a/internal/api/httpsrv/handler_test.go
+++ b/internal/api/httpsrv/handler_test.go
@@ -294,13 +294,13 @@ func TestAPIHandler(t *testing.T) {
 
 		withStoredIssuers(t, store, &iss1, &iss2, &iss3)
 
-		testCases := []testingx.TestCase[GetOwnerIssuersRequestObject, GetOwnerIssuersResponseObject]{
+		testCases := []testingx.TestCase[ListOwnerIssuersRequestObject, ListOwnerIssuersResponseObject]{
 			{
 				Name: "Success (Default Pagination)",
-				Input: GetOwnerIssuersRequestObject{
+				Input: ListOwnerIssuersRequestObject{
 					OwnerID: issOwnerID,
 				},
-				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[GetOwnerIssuersResponseObject]) {
+				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[ListOwnerIssuersResponseObject]) {
 					if !assert.NoError(t, result.Err) {
 						return
 					}
@@ -311,7 +311,7 @@ func TestAPIHandler(t *testing.T) {
 						Limit: 10,
 					}
 
-					resp, ok := result.Success.(GetOwnerIssuers200JSONResponse)
+					resp, ok := result.Success.(ListOwnerIssuers200JSONResponse)
 					if !ok {
 						assert.FailNow(t, "unexpected result type for get issuer response")
 					}
@@ -322,13 +322,13 @@ func TestAPIHandler(t *testing.T) {
 			},
 			{
 				Name: "Success with limit",
-				Input: GetOwnerIssuersRequestObject{
+				Input: ListOwnerIssuersRequestObject{
 					OwnerID: issOwnerID,
-					Params: v1.GetOwnerIssuersParams{
+					Params: v1.ListOwnerIssuersParams{
 						Limit: ptr(1),
 					},
 				},
-				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[GetOwnerIssuersResponseObject]) {
+				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[ListOwnerIssuersResponseObject]) {
 					if !assert.NoError(t, result.Err) {
 						return
 					}
@@ -340,7 +340,7 @@ func TestAPIHandler(t *testing.T) {
 						Next:  pagination.MustNewCursor("id", iss1.ID.String()),
 					}
 
-					resp, ok := result.Success.(GetOwnerIssuers200JSONResponse)
+					resp, ok := result.Success.(ListOwnerIssuers200JSONResponse)
 					if !ok {
 						assert.FailNow(t, "unexpected result type for get issuer response")
 					}
@@ -351,14 +351,14 @@ func TestAPIHandler(t *testing.T) {
 			},
 			{
 				Name: "Success with cursor",
-				Input: GetOwnerIssuersRequestObject{
+				Input: ListOwnerIssuersRequestObject{
 					OwnerID: issOwnerID,
-					Params: v1.GetOwnerIssuersParams{
+					Params: v1.ListOwnerIssuersParams{
 						Cursor: pagination.MustNewCursor("id", iss1.ID.String()),
 						Limit:  ptr(1),
 					},
 				},
-				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[GetOwnerIssuersResponseObject]) {
+				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[ListOwnerIssuersResponseObject]) {
 					if !assert.NoError(t, result.Err) {
 						return
 					}
@@ -370,7 +370,7 @@ func TestAPIHandler(t *testing.T) {
 						Next:  pagination.MustNewCursor("id", iss2.ID.String()),
 					}
 
-					resp, ok := result.Success.(GetOwnerIssuers200JSONResponse)
+					resp, ok := result.Success.(ListOwnerIssuers200JSONResponse)
 					if !ok {
 						assert.FailNow(t, "unexpected result type for get issuer response")
 					}
@@ -381,14 +381,14 @@ func TestAPIHandler(t *testing.T) {
 			},
 			{
 				Name: "Success with cursor end of results",
-				Input: GetOwnerIssuersRequestObject{
+				Input: ListOwnerIssuersRequestObject{
 					OwnerID: issOwnerID,
-					Params: v1.GetOwnerIssuersParams{
+					Params: v1.ListOwnerIssuersParams{
 						Cursor: pagination.MustNewCursor("id", v1iss2.ID.String()),
 						Limit:  ptr(1),
 					},
 				},
-				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[GetOwnerIssuersResponseObject]) {
+				CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[ListOwnerIssuersResponseObject]) {
 					if !assert.NoError(t, result.Err) {
 						return
 					}
@@ -399,7 +399,7 @@ func TestAPIHandler(t *testing.T) {
 						Limit: 1,
 					}
 
-					resp, ok := result.Success.(GetOwnerIssuers200JSONResponse)
+					resp, ok := result.Success.(ListOwnerIssuers200JSONResponse)
 					if !ok {
 						assert.FailNow(t, "unexpected result type for get issuer response")
 					}
@@ -410,12 +410,12 @@ func TestAPIHandler(t *testing.T) {
 			},
 		}
 
-		runFn := func(ctx context.Context, input GetOwnerIssuersRequestObject) testingx.TestResult[GetOwnerIssuersResponseObject] {
+		runFn := func(ctx context.Context, input ListOwnerIssuersRequestObject) testingx.TestResult[ListOwnerIssuersResponseObject] {
 			ctx = pagination.AsOfSystemTime(ctx, "")
 
-			resp, err := handler.GetOwnerIssuers(ctx, input)
+			resp, err := handler.ListOwnerIssuers(ctx, input)
 
-			result := testingx.TestResult[GetOwnerIssuersResponseObject]{
+			result := testingx.TestResult[ListOwnerIssuersResponseObject]{
 				Success: resp,
 				Err:     err,
 			}

--- a/internal/api/httpsrv/server.gen.go
+++ b/internal/api/httpsrv/server.gen.go
@@ -33,6 +33,9 @@ type ServerInterface interface {
 	// Updates an issuer.
 	// (PATCH /api/v1/issuers/{id})
 	UpdateIssuer(ctx echo.Context, id gidx.PrefixedID) error
+	// Gets users by issuer id
+	// (GET /api/v1/issuers/{id}/users)
+	GetIssuerUsers(ctx echo.Context, issuerID IssuerID, params GetIssuerUsersParams) error
 	// Gets oauth clients by owner id
 	// (GET /api/v1/owners/{ownerID}/clients)
 	GetOwnerOAuthClients(ctx echo.Context, ownerID OwnerID, params GetOwnerOAuthClientsParams) error
@@ -132,6 +135,38 @@ func (w *ServerInterfaceWrapper) UpdateIssuer(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.UpdateIssuer(ctx, id)
+	return err
+}
+
+// GetIssuerUsers converts echo context to params.
+func (w *ServerInterfaceWrapper) GetIssuerUsers(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "id" -------------
+	var issuerID IssuerID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", ctx.Param("id"), &issuerID, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter id: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetIssuerUsersParams
+	// ------------- Optional query parameter "cursor" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "cursor", ctx.QueryParams(), &params.Cursor)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter cursor: %s", err))
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", ctx.QueryParams(), &params.Limit)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter limit: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.GetIssuerUsers(ctx, issuerID, params)
 	return err
 }
 
@@ -280,6 +315,7 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.DELETE(baseURL+"/api/v1/issuers/:id", wrapper.DeleteIssuer)
 	router.GET(baseURL+"/api/v1/issuers/:id", wrapper.GetIssuerByID)
 	router.PATCH(baseURL+"/api/v1/issuers/:id", wrapper.UpdateIssuer)
+	router.GET(baseURL+"/api/v1/issuers/:id/users", wrapper.GetIssuerUsers)
 	router.GET(baseURL+"/api/v1/owners/:ownerID/clients", wrapper.GetOwnerOAuthClients)
 	router.POST(baseURL+"/api/v1/owners/:ownerID/clients", wrapper.CreateOAuthClient)
 	router.GET(baseURL+"/api/v1/owners/:ownerID/issuers", wrapper.GetOwnerIssuers)
@@ -300,6 +336,12 @@ type OAuthClientCollectionJSONResponse struct {
 
 	// Pagination collection response pagination
 	Pagination Pagination `json:"pagination"`
+}
+
+type UserCollectionJSONResponse struct {
+	// Pagination collection response pagination
+	Pagination Pagination `json:"pagination"`
+	Users      []User     `json:"users"`
 }
 
 type DeleteOAuthClientRequestObject struct {
@@ -382,6 +424,24 @@ type UpdateIssuerResponseObject interface {
 type UpdateIssuer200JSONResponse Issuer
 
 func (response UpdateIssuer200JSONResponse) VisitUpdateIssuerResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetIssuerUsersRequestObject struct {
+	IssuerID IssuerID `json:"id"`
+	Params   GetIssuerUsersParams
+}
+
+type GetIssuerUsersResponseObject interface {
+	VisitGetIssuerUsersResponse(w http.ResponseWriter) error
+}
+
+type GetIssuerUsers200JSONResponse struct{ UserCollectionJSONResponse }
+
+func (response GetIssuerUsers200JSONResponse) VisitGetIssuerUsersResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
@@ -496,6 +556,9 @@ type StrictServerInterface interface {
 	// Updates an issuer.
 	// (PATCH /api/v1/issuers/{id})
 	UpdateIssuer(ctx context.Context, request UpdateIssuerRequestObject) (UpdateIssuerResponseObject, error)
+	// Gets users by issuer id
+	// (GET /api/v1/issuers/{id}/users)
+	GetIssuerUsers(ctx context.Context, request GetIssuerUsersRequestObject) (GetIssuerUsersResponseObject, error)
 	// Gets oauth clients by owner id
 	// (GET /api/v1/owners/{ownerID}/clients)
 	GetOwnerOAuthClients(ctx context.Context, request GetOwnerOAuthClientsRequestObject) (GetOwnerOAuthClientsResponseObject, error)
@@ -650,6 +713,32 @@ func (sh *strictHandler) UpdateIssuer(ctx echo.Context, id gidx.PrefixedID) erro
 		return err
 	} else if validResponse, ok := response.(UpdateIssuerResponseObject); ok {
 		return validResponse.VisitUpdateIssuerResponse(ctx.Response())
+	} else if response != nil {
+		return fmt.Errorf("unexpected response type: %T", response)
+	}
+	return nil
+}
+
+// GetIssuerUsers operation middleware
+func (sh *strictHandler) GetIssuerUsers(ctx echo.Context, issuerID IssuerID, params GetIssuerUsersParams) error {
+	var request GetIssuerUsersRequestObject
+
+	request.IssuerID = issuerID
+	request.Params = params
+
+	handler := func(ctx echo.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.GetIssuerUsers(ctx.Request().Context(), request.(GetIssuerUsersRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetIssuerUsers")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		return err
+	} else if validResponse, ok := response.(GetIssuerUsersResponseObject); ok {
+		return validResponse.VisitGetIssuerUsersResponse(ctx.Response())
 	} else if response != nil {
 		return fmt.Errorf("unexpected response type: %T", response)
 	}

--- a/internal/crdbx/cursor.go
+++ b/internal/crdbx/cursor.go
@@ -105,6 +105,16 @@ func NewCursor(kvpairs ...string) (*Cursor, error) {
 	return NewCursorFromValues(values)
 }
 
+// MustNewCursor calls [NewCursor]. If an error is returned panic is called.
+func MustNewCursor(kvpairs ...string) *Cursor {
+	cursor, err := NewCursor(kvpairs...)
+	if err != nil {
+		panic(err)
+	}
+
+	return cursor
+}
+
 // NewCursorFromValues creates a new pagination cursor from url values.
 func NewCursorFromValues(values url.Values) (*Cursor, error) {
 	if values == nil {

--- a/internal/crdbx/cursor.go
+++ b/internal/crdbx/cursor.go
@@ -1,0 +1,117 @@
+package crdbx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+)
+
+// Cursor handles encoding and decoding a pagination cursor values.
+type Cursor string
+
+// Values parses the cursor returning the values.
+func (c *Cursor) Values() (url.Values, error) {
+	if c == nil || *c == "" {
+		return nil, nil
+	}
+
+	cursor, err := base64.URLEncoding.DecodeString(string(*c))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPaginationCursor, err)
+	}
+
+	values, err := url.ParseQuery(string(cursor))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPaginationCursor, err)
+	}
+
+	return values, nil
+}
+
+// Set lets you define include a field in the cursor.
+func (c *Cursor) Set(key, value string) error {
+	var (
+		values = url.Values{}
+		err    error
+	)
+
+	if c != nil {
+		values, err = c.Values()
+		if err != nil {
+			return err
+		}
+	}
+
+	values.Set(key, value)
+
+	cursor, err := NewCursorFromValues(values)
+	if err != nil {
+		return err
+	}
+
+	*c = *cursor
+
+	return nil
+}
+
+// String returns a string value of the cursor.
+func (c *Cursor) String() string {
+	if c == nil {
+		return ""
+	}
+
+	return string(*c)
+}
+
+// StringPtr returns a pointer to the string value of the cursor.
+func (c *Cursor) StringPtr() *string {
+	if c == nil {
+		return nil
+	}
+
+	v := c.String()
+
+	return &v
+}
+
+// MarshalJSON implements json marshaller.
+func (c *Cursor) MarshalJSON() ([]byte, error) {
+	if c == nil || *c == "" {
+		return []byte("null"), nil
+	}
+
+	return json.Marshal(string(*c))
+}
+
+// NewCursor creates a new pagination cursor from key/value pairs.
+func NewCursor(kvpairs ...string) (*Cursor, error) {
+	if len(kvpairs) == 0 {
+		return nil, nil
+	}
+
+	if len(kvpairs)%2 != 0 {
+		return nil, fmt.Errorf("%w: incorrect key/value pairs", ErrInvalidPaginationCursor)
+	}
+
+	values := url.Values{}
+
+	for i := 0; i < len(kvpairs); i += 2 {
+		if kvpairs[i+1] != "" {
+			values.Set(kvpairs[i], kvpairs[i+1])
+		}
+	}
+
+	return NewCursorFromValues(values)
+}
+
+// NewCursorFromValues creates a new pagination cursor from url values.
+func NewCursorFromValues(values url.Values) (*Cursor, error) {
+	if values == nil {
+		return nil, nil
+	}
+
+	cursor := Cursor(base64.URLEncoding.EncodeToString([]byte(values.Encode())))
+
+	return &cursor, nil
+}

--- a/internal/crdbx/doc.go
+++ b/internal/crdbx/doc.go
@@ -1,0 +1,2 @@
+// Package crdbx implements cursor pagination for crdb.
+package crdbx

--- a/internal/crdbx/pagination.go
+++ b/internal/crdbx/pagination.go
@@ -1,6 +1,7 @@
 package crdbx
 
 import (
+	"context"
 	"errors"
 	"slices"
 )
@@ -97,4 +98,23 @@ func Paginate(p Paginator, asOfSystemTime any) FormatValues {
 	}
 
 	return values
+}
+
+type asOfSystemTimeCtx struct{}
+
+var asOfSystemTimeCtxKey asOfSystemTimeCtx
+
+// ContextAsOfSystemTime retrieves the `AS OF SYSTEM TIME` value from the context.
+// If no value is found the default value is returned.
+func ContextAsOfSystemTime(ctx context.Context, defaultTime any) any {
+	if value := ctx.Value(asOfSystemTimeCtxKey); value != nil {
+		return value
+	}
+
+	return defaultTime
+}
+
+// AsOfSystemTime sets the `AS OF SYSTEM TIME` context value to be used.
+func AsOfSystemTime(ctx context.Context, value any) context.Context {
+	return context.WithValue(ctx, asOfSystemTimeCtxKey, value)
 }

--- a/internal/crdbx/pagination.go
+++ b/internal/crdbx/pagination.go
@@ -1,0 +1,100 @@
+package crdbx
+
+import (
+	"errors"
+	"slices"
+)
+
+const (
+	paginationLimitMax     = 100
+	paginationLimitDefault = 10
+)
+
+// ErrInvalidPaginationCursor is returned when there's an error handling the cursor.
+var ErrInvalidPaginationCursor = errors.New("invalid pagination cursor")
+
+// Paginator provides the necessary details to paginate a database request.
+type Paginator interface {
+	GetCursor() *Cursor
+	GetLimit() int
+	GetOnlyFields() []string
+}
+
+var _ Paginator = Pagination{}
+
+// Pagination define pagination query parameters.
+type Pagination struct {
+	Cursor     *Cursor
+	Limit      int
+	OnlyFields []string
+}
+
+// GetCursor implements [Paginator] returning the cursor
+func (p Pagination) GetCursor() *Cursor {
+	return p.Cursor
+}
+
+// GetLimit implements [Paginator] returning the effective limit.
+func (p Pagination) GetLimit() int {
+	return p.Limit
+}
+
+// GetOnlyFields implements [Paginator] returning the permitted fields.
+func (p Pagination) GetOnlyFields() []string {
+	return p.OnlyFields
+}
+
+// Limit accepts a requested limit, returning an acceptable limit.
+func Limit(limit int) int {
+	switch {
+	case limit > paginationLimitMax:
+		limit = paginationLimitMax
+	case limit <= 0:
+		limit = paginationLimitDefault
+	}
+
+	return limit
+}
+
+// Paginate handles setting the pagination for the request.
+func Paginate(p Paginator, asOfSystemTime any) FormatValues {
+	var values FormatValues
+
+	values.limit = p.GetLimit()
+
+	if asOfSystemTime != nil {
+		values.asOfSystemTime = asOfSystemTime
+	}
+
+	onlyFields := p.GetOnlyFields()
+
+	if len(onlyFields) == 0 {
+		onlyFields = []string{"id"}
+	}
+
+	values.orderFields = onlyFields
+
+	if cursor := p.GetCursor(); cursor != nil {
+		cValues, err := cursor.Values()
+		if err != nil {
+			return FormatValues{}
+		}
+
+		// Ensure only permitted fields are defined.
+		for key := range cValues {
+			if !slices.Contains(onlyFields, key) {
+				return FormatValues{}
+			}
+		}
+
+		// Add clauses in original field order.
+		for _, field := range onlyFields {
+			if value := cValues.Get(field); value != "" {
+				values.fields = append(values.fields, field)
+				values.values = append(values.values, value)
+			}
+		}
+	}
+
+	return values
+}

--- a/internal/crdbx/template_values.go
+++ b/internal/crdbx/template_values.go
@@ -1,0 +1,124 @@
+package crdbx
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	pgTimestampFormat = "2006-01-02 15:04:05.999999999"
+	defaultLimit      = 10
+)
+
+var defaultOrderFields = []string{"id"}
+
+type FormatValues struct {
+	asOfSystemTime any
+	fields         []string
+	values         []any
+	orderFields    []string
+	limit          int
+}
+
+// AsOfSystemTime if set will be formatted as `AS OF SYSTEM TIME` followed by a value.
+// This value should be included directly after a `FROM` in the query.
+func (v FormatValues) AsOfSystemTime() string {
+	var value string
+
+	if v.asOfSystemTime != nil {
+		switch v := v.asOfSystemTime.(type) {
+		case string:
+			value = v
+		case *string:
+			value = *v
+		case time.Time:
+			// https://github.com/jackc/pgx/blob/9907b874c223887dba628215feae29be69306e73/pgtype/timestamp.go#L203
+			value = discardTimeZone(v).Truncate(time.Microsecond).Format(pgTimestampFormat)
+		}
+	}
+
+	if value == "" {
+		return ""
+	}
+
+	// https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
+	return "AS OF SYSTEM TIME " + `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
+}
+
+func (v FormatValues) Where(next int) string {
+	if len(v.fields) == 0 {
+		return ""
+	}
+
+	where := make([]string, len(v.fields))
+	for i, field := range v.fields {
+		where[i] = `"` + strings.ReplaceAll(field, `"`, `""`) + `">$` + strconv.Itoa(i+next)
+	}
+
+	return "(" + strings.Join(where, " AND ") + ")"
+}
+
+func (v FormatValues) WhereClause(next int) string {
+	where := v.Where(next)
+	if where == "" {
+		return ""
+	}
+
+	return "WHERE " + where
+}
+
+func (v FormatValues) AndWhere(next int) string {
+	where := v.Where(next)
+	if where == "" {
+		return ""
+	}
+
+	return "AND " + where
+}
+
+func (v FormatValues) LimitClause() string {
+	if v.limit <= 0 {
+		v.limit = defaultLimit
+	}
+
+	return "LIMIT " + strconv.Itoa(v.limit)
+}
+
+func (v FormatValues) OrderClause(fields ...string) string {
+	order := v.Order(fields...)
+	if order == "" {
+		return ""
+	}
+
+	return "ORDER BY " + order
+}
+
+func (v FormatValues) Order(fields ...string) string {
+	fields = append(fields, v.orderFields...)
+
+	if len(fields) == 0 {
+		return ""
+	}
+
+	for i, field := range fields {
+		fields[i] = `"` + strings.ReplaceAll(field, `"`, `""`) + `"`
+	}
+
+	return strings.Join(fields, ",")
+}
+
+func (v FormatValues) Values(values ...any) []any {
+	values = append(values, v.values...)
+
+	return values
+}
+
+// https://github.com/jackc/pgx/blob/9907b874c223887dba628215feae29be69306e73/pgtype/timestamp.go#L219
+func discardTimeZone(t time.Time) time.Time {
+	if t.Location() != time.UTC {
+		return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC)
+	}
+
+	return t
+}

--- a/internal/storage/issuer.go
+++ b/internal/storage/issuer.go
@@ -116,7 +116,7 @@ func (s *issuerService) GetIssuerByID(ctx context.Context, id gidx.PrefixedID) (
 
 // GetOwnerIssuers lists issuers by it's owners ID.
 func (s *issuerService) GetOwnerIssuers(ctx context.Context, id gidx.PrefixedID, pagination crdbx.Paginator) (types.Issuers, error) {
-	paginate := crdbx.Paginate(pagination, "-1m")
+	paginate := crdbx.Paginate(pagination, crdbx.ContextAsOfSystemTime(ctx, "-1m"))
 
 	query := fmt.Sprintf("SELECT %s FROM issuers %s WHERE owner_id = $1 %s %s %s", issuerColumnsStr,
 		paginate.AsOfSystemTime(),

--- a/internal/storage/oauth_client.go
+++ b/internal/storage/oauth_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ory/fosite"
+	"go.infratographer.com/identity-api/internal/crdbx"
 	"go.infratographer.com/identity-api/internal/types"
 	"go.infratographer.com/x/gidx"
 )
@@ -176,4 +177,49 @@ func (s *oauthClientManager) LookupOAuthClientByID(ctx context.Context, clientID
 	model.Audience = strings.Fields(aud)
 
 	return model, nil
+}
+
+// GetOwnerOAuthClients lists issuers by it's owners ID.
+func (s *oauthClientManager) GetOwnerOAuthClients(ctx context.Context, id gidx.PrefixedID, pagination crdbx.Paginator) (types.OAuthClients, error) {
+	paginate := crdbx.Paginate(pagination, "-1m")
+
+	query := fmt.Sprintf("SELECT %s FROM oauth_clients %s WHERE owner_id = $1 %s %s %s", oauthClientColumnsStr,
+		paginate.AsOfSystemTime(),
+		paginate.AndWhere(2), //nolint:gomnd
+		paginate.OrderClause(),
+		paginate.LimitClause(),
+	)
+
+	rows, err := s.db.QueryContext(ctx, query, paginate.Values(id)...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var clients types.OAuthClients
+
+	for rows.Next() {
+		var (
+			model types.OAuthClient
+			aud   string
+		)
+
+		err = rows.Scan(
+			&model.ID,
+			&model.OwnerID,
+			&model.Name,
+			&model.Secret,
+			&aud,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		model.Audience = strings.Fields(aud)
+
+		clients = append(clients, model)
+	}
+
+	return clients, nil
 }

--- a/internal/storage/oauth_client.go
+++ b/internal/storage/oauth_client.go
@@ -181,7 +181,7 @@ func (s *oauthClientManager) LookupOAuthClientByID(ctx context.Context, clientID
 
 // GetOwnerOAuthClients lists issuers by it's owners ID.
 func (s *oauthClientManager) GetOwnerOAuthClients(ctx context.Context, id gidx.PrefixedID, pagination crdbx.Paginator) (types.OAuthClients, error) {
-	paginate := crdbx.Paginate(pagination, "-1m")
+	paginate := crdbx.Paginate(pagination, crdbx.ContextAsOfSystemTime(ctx, "-1m"))
 
 	query := fmt.Sprintf("SELECT %s FROM oauth_clients %s WHERE owner_id = $1 %s %s %s", oauthClientColumnsStr,
 		paginate.AsOfSystemTime(),

--- a/internal/storage/userinfo.go
+++ b/internal/storage/userinfo.go
@@ -199,7 +199,7 @@ func (s userInfoService) LookupUserOwnerID(ctx context.Context, id gidx.Prefixed
 
 // LookupUserInfosByIssuerID lists users for an issuer.
 func (s *userInfoService) LookupUserInfosByIssuerID(ctx context.Context, id gidx.PrefixedID, pagination crdbx.Paginator) (types.UserInfos, error) {
-	paginate := crdbx.Paginate(pagination, "-1m").WithQualifier("user_info")
+	paginate := crdbx.Paginate(pagination, crdbx.ContextAsOfSystemTime(ctx, "-1m")).WithQualifier("user_info")
 
 	selectCols := withQualifier([]string{
 		userInfoCols.ID,

--- a/internal/types/client.go
+++ b/internal/types/client.go
@@ -6,6 +6,20 @@ import (
 	"go.infratographer.com/x/gidx"
 )
 
+// OAuthClients represents a list of token issuers.
+type OAuthClients []OAuthClient
+
+// ToV1OAuthClients converts an slice of issuers to a slice of API issuers.
+func (i OAuthClients) ToV1OAuthClients() ([]v1.OAuthClient, error) {
+	clients := make([]v1.OAuthClient, len(i))
+
+	for i, client := range i {
+		clients[i] = client.ToV1OAuthClient()
+	}
+
+	return clients, nil
+}
+
 // OAuthClient is an OAuth 2.0 Client
 type OAuthClient struct {
 	ID       gidx.PrefixedID

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -183,6 +183,25 @@ func BuildClaimsMappingFromMap(in map[string]*exprpb.CheckedExpr) ClaimsMapping 
 	return out
 }
 
+// UserInfos represents a list of token issuers.
+type UserInfos []UserInfo
+
+// ToV1Users converts an slice of issuers to a slice of API issuers.
+func (i UserInfos) ToV1Users() ([]v1.User, error) {
+	users := make([]v1.User, len(i))
+
+	for i, user := range i {
+		v1user, err := user.ToV1User()
+		if err != nil {
+			return nil, err
+		}
+
+		users[i] = v1user
+	}
+
+	return users, nil
+}
+
 // UserInfo contains information about the user from the source OIDC provider.
 // As defined in https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 type UserInfo struct {
@@ -230,6 +249,9 @@ type UserInfoService interface {
 
 	// LookupUserOwnerID finds the Owner ID of the Issuer for the given User ID.
 	LookupUserOwnerID(ctx context.Context, id gidx.PrefixedID) (gidx.PrefixedID, error)
+
+	// LookupUserInfosByIssuerID returns the user infos for an STS issuer ID
+	LookupUserInfosByIssuerID(ctx context.Context, id gidx.PrefixedID, paginator crdbx.Paginator) (UserInfos, error)
 
 	// StoreUserInfo stores the userInfo into the storage backend.
 	StoreUserInfo(ctx context.Context, userInfo UserInfo) (UserInfo, error)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -243,4 +243,5 @@ type OAuthClientManager interface {
 	CreateOAuthClient(ctx context.Context, client OAuthClient) (OAuthClient, error)
 	LookupOAuthClientByID(ctx context.Context, clientID gidx.PrefixedID) (OAuthClient, error)
 	DeleteOAuthClient(ctx context.Context, clientID gidx.PrefixedID) error
+	GetOwnerOAuthClients(ctx context.Context, ownerID gidx.PrefixedID, pagination crdbx.Paginator) (OAuthClients, error)
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -10,9 +10,29 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"go.infratographer.com/identity-api/internal/celutils"
+	"go.infratographer.com/identity-api/internal/crdbx"
 	v1 "go.infratographer.com/identity-api/pkg/api/v1"
 	"go.infratographer.com/x/gidx"
 )
+
+// Issuers represents a list of token issuers.
+type Issuers []*Issuer
+
+// ToV1Issuers converts an slice of issuers to a slice of API issuers.
+func (i Issuers) ToV1Issuers() ([]v1.Issuer, error) {
+	issuers := make([]v1.Issuer, len(i))
+
+	for i, iss := range i {
+		v1iss, err := iss.ToV1Issuer()
+		if err != nil {
+			return nil, err
+		}
+
+		issuers[i] = v1iss
+	}
+
+	return issuers, nil
+}
 
 // Issuer represents a token issuer.
 type Issuer struct {
@@ -60,6 +80,7 @@ type IssuerUpdate struct {
 type IssuerService interface {
 	CreateIssuer(ctx context.Context, iss Issuer) (*Issuer, error)
 	GetIssuerByID(ctx context.Context, id gidx.PrefixedID) (*Issuer, error)
+	GetOwnerIssuers(ctx context.Context, id gidx.PrefixedID, pagination crdbx.Paginator) (Issuers, error)
 	GetIssuerByURI(ctx context.Context, uri string) (*Issuer, error)
 	UpdateIssuer(ctx context.Context, id gidx.PrefixedID, update IssuerUpdate) (*Issuer, error)
 	DeleteIssuer(ctx context.Context, id gidx.PrefixedID) error

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -47,6 +47,18 @@ paths:
                 $ref: '#/components/schemas/Issuer'
 
   /api/v1/owners/{ownerID}/clients:
+    get:
+      summary: Gets oauth clients by owner id
+      operationId: GetOwnerOAuthClients
+      tags:
+        - OAuthClients
+      parameters:
+        - $ref: '#/components/parameters/ownerID'
+        - $ref: '#/components/parameters/pageCursor'
+        - $ref: '#/components/parameters/pageLimit'
+      responses:
+        '200':
+          $ref: '#/components/responses/OAuthClientCollection'
     post:
       tags:
         - OAuthClients
@@ -420,5 +432,21 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/Issuer'
+              pagination:
+                $ref: '#/components/schemas/Pagination'
+    OAuthClientCollection:
+      description: a collection of OAuth Clients
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - clients
+              - pagination
+            properties:
+              clients:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OAuthClient'
               pagination:
                 $ref: '#/components/schemas/Pagination'

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -198,6 +198,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/DeleteResponse'
 
+  /api/v1/issuers/{id}/users:
+    get:
+      summary: Gets users by issuer id
+      operationId: GetIssuerUsers
+      tags:
+        - Issuers
+      parameters:
+        - $ref: '#/components/parameters/issuerID'
+        - $ref: '#/components/parameters/pageCursor'
+        - $ref: '#/components/parameters/pageLimit'
+      responses:
+        '200':
+          $ref: '#/components/responses/UserCollection'
+
   /api/v1/users/{userID}:
     get:
       tags:
@@ -395,6 +409,17 @@ components:
         x-go-type: gidx.PrefixedID
         x-go-type-import:
           path: go.infratographer.com/x/gidx
+    issuerID:
+      description: id of an issuer
+      in: path
+      name: id
+      x-go-name: IssuerID
+      required: true
+      schema:
+        type: string
+        x-go-type: gidx.PrefixedID
+        x-go-type-import:
+          path: go.infratographer.com/x/gidx
     pageCursor:
       description: the cursor to the results to return
       in: query
@@ -448,5 +473,21 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/OAuthClient'
+              pagination:
+                $ref: '#/components/schemas/Pagination'
+    UserCollection:
+      description: a collection of users
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - users
+              - pagination
+            properties:
+              users:
+                type: array
+                items:
+                  $ref: '#/components/schemas/User'
               pagination:
                 $ref: '#/components/schemas/Pagination'

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -14,7 +14,7 @@ paths:
   /api/v1/owners/{ownerID}/issuers:
     get:
       summary: Gets issuers by owner id
-      operationId: GetOwnerIssuers
+      operationId: ListOwnerIssuers
       tags:
         - Issuers
       parameters:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -5,6 +5,11 @@ info:
   description: Security Token Service (STS) Management API is an API for managing STS configurations.
   version: 0.0.1
 
+tags:
+  - name: Issuers
+  - name: OAuthClients
+  - name: Users
+
 paths:
   /api/v1/owners/{ownerID}/issuers:
     get:

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -7,6 +7,18 @@ info:
 
 paths:
   /api/v1/owners/{ownerID}/issuers:
+    get:
+      summary: Gets issuers by owner id
+      operationId: GetOwnerIssuers
+      tags:
+        - Issuers
+      parameters:
+        - $ref: '#/components/parameters/ownerID'
+        - $ref: '#/components/parameters/pageCursor'
+        - $ref: '#/components/parameters/pageLimit'
+      responses:
+        '200':
+          $ref: '#/components/responses/IssuerCollection'
     post:
       tags:
         - Issuers
@@ -339,3 +351,74 @@ components:
           x-go-name: Subject
           type: string
           description: OAuth 2.0 Subject for the user
+
+    Pagination:
+      description: collection response pagination
+      type: object
+      required:
+        - limit
+      properties:
+        limit:
+          type: integer
+          description: the limit used for the collection response
+          example: 10
+          x-order: 1
+        next:
+          type: string
+          description: the cursor for the next page
+          example: aWQ9ZXhhbXBsZS1hZnRlci10aGlzLWlk
+          x-go-type: crdbx.Cursor
+          x-go-type-import:
+            path: go.infratographer.com/identity-api/internal/crdbx
+
+  parameters:
+    ownerID:
+      description: id of a resource owner
+      in: path
+      name: ownerID
+      x-go-name: OwnerID
+      required: true
+      schema:
+        type: string
+        x-go-type: gidx.PrefixedID
+        x-go-type-import:
+          path: go.infratographer.com/x/gidx
+    pageCursor:
+      description: the cursor to the results to return
+      in: query
+      name: cursor
+      required: false
+      schema:
+        type: string
+        x-go-type: crdbx.Cursor
+        x-go-type-import:
+          path: go.infratographer.com/identity-api/internal/crdbx
+      x-oapi-codegen-extra-tags:
+        query: "cursor"
+    pageLimit:
+      description: limits the response collections
+      in: query
+      name: limit
+      required: false
+      schema:
+        type: integer
+      x-oapi-codegen-extra-tags:
+        query: "limit"
+
+  responses:
+    IssuerCollection:
+      description: a collection of issuers
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - issuers
+              - pagination
+            properties:
+              issuers:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Issuer'
+              pagination:
+                $ref: '#/components/schemas/Pagination'

--- a/pkg/api/v1/paginate_clients.go
+++ b/pkg/api/v1/paginate_clients.go
@@ -1,0 +1,40 @@
+package v1
+
+import "go.infratographer.com/identity-api/internal/crdbx"
+
+var _ crdbx.Paginator = GetOwnerOAuthClientsParams{}
+
+// GetCursor implements crdbx.Paginator returning the cursor.
+func (p GetOwnerOAuthClientsParams) GetCursor() *crdbx.Cursor {
+	return p.Cursor
+}
+
+// GetLimit implements crdbx.Paginator returning requested limit.
+func (p GetOwnerOAuthClientsParams) GetLimit() int {
+	if p.Limit == nil {
+		return 0
+	}
+
+	return *p.Limit
+}
+
+// GetOnlyFields implements crdbx.Paginator setting the only permitted field to `id`.
+func (p GetOwnerOAuthClientsParams) GetOnlyFields() []string {
+	return []string{"id"}
+}
+
+// SetPagination sets the pagination on the provided collection.
+func (p GetOwnerOAuthClientsParams) SetPagination(collection *OAuthClientCollection) error {
+	collection.Pagination.Limit = crdbx.Limit(p.GetLimit())
+
+	if count := len(collection.Clients); count != 0 && count == collection.Pagination.Limit {
+		cursor, err := crdbx.NewCursor("id", collection.Clients[count-1].ID.String())
+		if err != nil {
+			return err
+		}
+
+		collection.Pagination.Next = cursor
+	}
+
+	return nil
+}

--- a/pkg/api/v1/paginate_issuer_users.go
+++ b/pkg/api/v1/paginate_issuer_users.go
@@ -1,0 +1,40 @@
+package v1
+
+import "go.infratographer.com/identity-api/internal/crdbx"
+
+var _ crdbx.Paginator = GetIssuerUsersParams{}
+
+// GetCursor implements crdbx.Paginator returning the cursor.
+func (p GetIssuerUsersParams) GetCursor() *crdbx.Cursor {
+	return p.Cursor
+}
+
+// GetLimit implements crdbx.Paginator returning requested limit.
+func (p GetIssuerUsersParams) GetLimit() int {
+	if p.Limit == nil {
+		return 0
+	}
+
+	return *p.Limit
+}
+
+// GetOnlyFields implements crdbx.Paginator setting the only permitted field to `id`.
+func (p GetIssuerUsersParams) GetOnlyFields() []string {
+	return []string{"id"}
+}
+
+// SetPagination sets the pagination on the provided collection.
+func (p GetIssuerUsersParams) SetPagination(collection *UserCollection) error {
+	collection.Pagination.Limit = crdbx.Limit(p.GetLimit())
+
+	if count := len(collection.Users); count != 0 && count == collection.Pagination.Limit {
+		cursor, err := crdbx.NewCursor("id", collection.Users[count-1].ID.String())
+		if err != nil {
+			return err
+		}
+
+		collection.Pagination.Next = cursor
+	}
+
+	return nil
+}

--- a/pkg/api/v1/paginate_issuers.go
+++ b/pkg/api/v1/paginate_issuers.go
@@ -2,15 +2,15 @@ package v1
 
 import "go.infratographer.com/identity-api/internal/crdbx"
 
-var _ crdbx.Paginator = GetOwnerIssuersParams{}
+var _ crdbx.Paginator = ListOwnerIssuersParams{}
 
 // GetCursor implements crdbx.Paginator returning the cursor.
-func (p GetOwnerIssuersParams) GetCursor() *crdbx.Cursor {
+func (p ListOwnerIssuersParams) GetCursor() *crdbx.Cursor {
 	return p.Cursor
 }
 
 // GetLimit implements crdbx.Paginator returning requested limit.
-func (p GetOwnerIssuersParams) GetLimit() int {
+func (p ListOwnerIssuersParams) GetLimit() int {
 	if p.Limit == nil {
 		return 0
 	}
@@ -19,12 +19,12 @@ func (p GetOwnerIssuersParams) GetLimit() int {
 }
 
 // GetOnlyFields implements crdbx.Paginator setting the only permitted field to `id`.
-func (p GetOwnerIssuersParams) GetOnlyFields() []string {
+func (p ListOwnerIssuersParams) GetOnlyFields() []string {
 	return []string{"id"}
 }
 
 // SetPagination sets the pagination on the provided collection.
-func (p GetOwnerIssuersParams) SetPagination(collection *IssuerCollection) error {
+func (p ListOwnerIssuersParams) SetPagination(collection *IssuerCollection) error {
 	collection.Pagination.Limit = crdbx.Limit(p.GetLimit())
 
 	if count := len(collection.Issuers); count != 0 && count == collection.Pagination.Limit {

--- a/pkg/api/v1/paginate_issuers.go
+++ b/pkg/api/v1/paginate_issuers.go
@@ -1,0 +1,40 @@
+package v1
+
+import "go.infratographer.com/identity-api/internal/crdbx"
+
+var _ crdbx.Paginator = GetOwnerIssuersParams{}
+
+// GetCursor implements crdbx.Paginator returning the cursor.
+func (p GetOwnerIssuersParams) GetCursor() *crdbx.Cursor {
+	return p.Cursor
+}
+
+// GetLimit implements crdbx.Paginator returning requested limit.
+func (p GetOwnerIssuersParams) GetLimit() int {
+	if p.Limit == nil {
+		return 0
+	}
+
+	return *p.Limit
+}
+
+// GetOnlyFields implements crdbx.Paginator setting the only permitted field to `id`.
+func (p GetOwnerIssuersParams) GetOnlyFields() []string {
+	return []string{"id"}
+}
+
+// SetPagination sets the pagination on the provided collection.
+func (p GetOwnerIssuersParams) SetPagination(collection *IssuerCollection) error {
+	collection.Pagination.Limit = crdbx.Limit(p.GetLimit())
+
+	if count := len(collection.Issuers); count != 0 && count == collection.Pagination.Limit {
+		cursor, err := crdbx.NewCursor("id", collection.Issuers[count-1].ID.String())
+		if err != nil {
+			return err
+		}
+
+		collection.Pagination.Next = cursor
+	}
+
+	return nil
+}

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -175,8 +175,8 @@ type GetOwnerOAuthClientsParams struct {
 	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty" query:"limit"`
 }
 
-// GetOwnerIssuersParams defines parameters for GetOwnerIssuers.
-type GetOwnerIssuersParams struct {
+// ListOwnerIssuersParams defines parameters for ListOwnerIssuers.
+type ListOwnerIssuersParams struct {
 	// Cursor the cursor to the results to return
 	Cursor *PageCursor `form:"cursor,omitempty" json:"cursor,omitempty" query:"cursor"`
 
@@ -196,35 +196,36 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZ3W7bOhJ+FYK7F7uAbDnnXG3uWrsI3G232ThBirZBQUtji61EqiSV2Bvo3RdDSpZk",
-	"yYqdpEHS0yvL0nA4f9/wI3lLA5mkUoAwmh7f0pQploABZf9xrTNQ0wk+h6ADxVPDpaDHlIdELggTxIlQ",
-	"j3J8nTITUY8KloAVoh5V8CPjCkJ6bFQGHtVBBAlDjWadopQ2iosl9ehqsJSD4uWSh6vhqYIFX0E4ndS/",
-	"DniSSmWctSZCYTnkYqGYkUvF0gjUMJCJv/JRCc3zYmxh1LT0KfeovBG97hEFWmYqAGIlu70slTw/Vz8U",
-	"luUeTdkSxpnSUrWdNRGQwH4jRhL8p0BnsdH4V4HJlCg9/5GBWleuu1F0X08DFc5Xw3E56GA3eQjCcLMe",
-	"sJT7XBhQgsW+1Vr4LlnKB4EMYQliACuj2MCwpa1lZ/rG5rwIyjuecNOOSYyvdRmMVAoNJJBxDAEK6B3x",
-	"sKO6woHGLkHRfY10inI0spzefnfFO94Ygu8CKQwI6wNL05gHDL/437T7XNmSKpmCMhxq2HaPBhL78HcF",
-	"C3pM/+ZXTcF347XvpkYPCp+YUmxd1BYXrDSnT8dpJelcK/HyeWNOQ93VZjI5/wZBEZFmplgtLwjaUlHu",
-	"0Q+vMhONYw7CPErIAqtq/5DV5v9pcSttenDcrLFkXKjLPXqhH6nS7uenRzN9SH2iue0ob0XLqXxwrJwa",
-	"lCtmR+PGCpiBAiYdtcN48jVhacqFwzoLQ44KWXzakGx20JYt4zfvCKxSBVpjJyKFSmLkdxDETmMbtzQR",
-	"qOI/bfno0W833/XXTPF273t7+e8ZuTibVqOa3bxodiiGUnnZ/rb1vCJRljAxUMBCNo+BoBhZ4DITQUUc",
-	"Wv52GnVxNt0aOiTvM21IwkwQ2ddfsIl8oc5ncs3iDAgXhItAJhiht5fn+g6frD9bNWM/OatqUbvKvSLj",
-	"dZS30s6ykIMIuqJTfMFFhhliIq6JAzMJmCBoAWhcTDbV3wrUdkO5TxrclO00dAUBfZ5ADAbOikWp7bDO",
-	"ggC07jAjvmFrTZAZDavp5lLGwNptrVSDU74YSPGw7fZ0gg2jp+C32OnkDnb4G7n7I9fuP7rh621XT1Vo",
-	"F2nIDPzu4C+5Dprk75C2fKKYMNbXUkYf1IO7eoCjVn8MRwW9IhblD20D3SmbVP+w8Yx3tHePaggUmB3G",
-	"1mydObm7Fog61jbRRVCdNthfc64aq9rssmrUzNvKWty9V8PKsZ+Ql4XVytZWTj0KK5akMdDjo5G3vTuz",
-	"mzMV4lpzhAGGlendLZczoSDa3dBP2eV///XpYxTNP77Wn2ZH0SdxFgf8aMRO4v+9u4y/7yqBJ9ksb2XP",
-	"Rfaqo8lYWt3CDySMx+3YvMHX5XqHJLmr8PoRgvM9Dj54FwupJnLNvtfYroOj3cj7D/bGO3zX2bzPpllm",
-	"474prD2sKoZ04xFD4Ca9sinnYiHb888gyBQ3a3JuF6AZqGseAPnH7Hz2T/KeCbaEBDvBq9Mp4ZowYZ/Q",
-	"xgQ/YmOenc9IIMWCLzNlsastx+PGImHHBE3V1KPXoLQzaTQcDY/sCV0KgqWcHtM/h6Phn3brZiKbWB8L",
-	"+/rIL3bA/q17mE5y5yLyVHzCurU2TUPbH/F9fXHwGoeen7uzE9Qad8cZYDn1ox0C5vnV1tHPH6PRQXvw",
-	"vr3yFonv2PHOHP9eZDGpiWEtJQmzR1ROhy2H+tEBpt0eZn2ur8COXy3detNMyAmYv3g2GsdE90nFCRhN",
-	"ENsqsfMTNpeZqTJTrebD3enJvQ2iiiM0/5aHe2BpWtLA3sS5fZDTjOS20Pmz7w2eEY7UnTgqonPDjaPD",
-	"S34Ngkwn9axNi+PNPjw5mddri4CDsrK0TO8lp6Rcpe+TCoujKg/zdU/sU9y0tKPvNo/3g0TmNp5PFH97",
-	"vPRahutHDn2xfd6imGhw/kzT7iyuZb475zsapL85pu6H48Xm6LlREl1OVSI+r24r75St3fHtKe0uv3bh",
-	"sUvBRs7fuh7oQJINDKKoKHFbw71xtVep2r8trlRzv3bjspM8oGxjLTs0xnJzTfrMQtx9f9URackqVmQj",
-	"bl1qBrzFxlKpOyLaPtO+i5HZqYwkqZLXHPm7XbsaRC0T4VPdnv+07tYOzBO3uAfTROdBjbEHB3DCFjRr",
-	"98e90JzWLnZ/CVS27uC7yLhzegcUGzyiB4WH0AhZwjCwQzc9V/wSsKsv7y+DVNTAtiepsMulf4s/xRnG",
-	"Llzh0rsPu6/O0joqwM3zQli9u9x/zL2xPWis58Txs6s8z/P/BwAA//8OF7IsFScAAA==",
+	"H4sIAAAAAAAC/+xaXVPbOBf+Kxq978XujBOH9mq5a5MOky7dsgSGTlumo9gnsVpbciUZkmX833eOZMd2",
+	"7IQEKAPdXuHYR0fn6zl6JHFDA5mkUoAwmh7e0JQploABZX9xrTNQ4xE+h6ADxVPDpaCHlIdEzggTxIlQ",
+	"j3J8nTITUY8KloAVoh5V8D3jCkJ6aFQGHtVBBAlDjWaZopQ2ios59eiiN5e94uWch4v+iYIZX0A4HtW/",
+	"9niSSmWctSZCYdnnYqaYkXPF0ghUP5CJv/BRCc3zYmxh1Lj0KfeovBZb3SMKtMxUAMRKdntZKnl6rr4v",
+	"LMs9mrI5DDOlpWo7ayIggf1GjCT4S4HOYqPxpwKTKVF6/j0Dtaxcd6Porp4GKpwu+sNy0N5u8hCE4WbZ",
+	"Yyn3uTCgBIt9q7XwXbKU9wIZwhxEDxZGsZ5hc1vLzvSVzXkRlGOecNOOSYyvdRmMVAoNJJBxDAEK6A3x",
+	"sKO6woHGzkHRXY10inI0spzefnfFO1wZgu8CKQwI6wNL05gHDL/4X7X7XNmSKpmCMhxq2HaPBhL78H8F",
+	"M3pI/+dXTcF347XvpkYPCp+YUmxZ1BYXrDRnm46TStK5VuLl08qchrrL1WRy+hWCIiLNTLFaXhC0paLc",
+	"o+9fZSYaxhyEeZCQBVbV7iGrzf/D4lbadO+4WWPJsFCXe/RcP1Cl3c1Pj2Z6n/pEc9tRXouWU3nvWDk1",
+	"KFfMjsYNFTADBUw6aofx5EvC0pQLh3UWhhwVsvikIdnsoC1bhm+OCSxSBVpjJyKFSmLkNxDETmMbtzQR",
+	"qOI3bfno0a/X3/SXTPF273t78eeEnJ+Oq1HNbl40OxRDqbxsf+t6XpEoS5joKWAhm8ZAUIzMcJmJoCIO",
+	"LX87jTo/Ha8N7ZN3mTYkYSaI7OvP2EQ+U+czuWJxBoQLwkUgE4zQ24szfYtP1p+1mrGfnFW1qF3mXpHx",
+	"OspbaWdZyEEEXdEpvuAiwwwxEdfEgZkETBC0ADQuJqvqbwVqvaHcJQ1uynYauoKAPo8gBgOnxaLUdlhn",
+	"QQBad5gRX7OlJsiM+tV0UyljYO22VqrBKZ8NpHjYdns8woaxpeDX2OnoFnb4C7m7I9fuP7rh661XT1Vo",
+	"52nIDPzq4M+5Dprkb5+2fKSYMNbXUkbv1YO7eoCjVi/6g4JeEYvy+7aB7pSNql/YeIYb2rtHNQQKzAZj",
+	"a7ZOnNxtC0Qda6voIqhOGuyvOVeNVa12WTVq5q1lLe7eq2Hl2E/Iy8JqZWsrpx6FBUvSGOjhwcBb353Z",
+	"zZkKca05wADDwmzdLZczoSDa3dBP2cXff3z8EEXTD6/1x8lB9FGcxgE/GLCj+J/ji/jbphJ4lM3yWvZc",
+	"ZC87moyl1S38QMJ43I7NG3xdrndIkrsKbztCcL6HwQfvYiHVRK7ZbzW26+BoM/L+wt54i+86m26zaZLZ",
+	"uK8KaweriiHdeMQQuEkvbcq5mMn2/BMIMsXNkpzZBWgC6ooHQH6bnE1+J++YYHNIsBO8OhkTrgkT9glt",
+	"TPAjNubJ2YQEUsz4PFMWu9pyPG4sEjZM0FRNPXoFSjuTBv1B/8Ce0KUgWMrpIX3ZH/Rf2q2biWxifSzs",
+	"qwO/2AH7N+5hPMqdi8hT8Qnr1to0Dm1/xPf1xcFrHHp+6s5OUGvcHWeA5dQPdgiY55drRz8vBoO99uDb",
+	"9sprJL5jxztx/HuWxaQmhrWUJMweUTkdthzqRweYdnuY9am+Ajt+NXfrTTMhR2D+49loHBPdJRVHYDRB",
+	"bKvEzk/YVGamyky1mvc3pyf3VogqjtD8Gx7ugKVxSQO3Js7tg5xmJLeFzh99b/CEcKRuxVERnWtuHB2e",
+	"8ysQZDyqZ21cHG9uw5OTeb20CNgrK3PL9J5zSspV+i6psDiq8jBdbol9ipuWdvTd5vFukMjcxvOR4m+P",
+	"l17LcPnAoS+2z2sUEw3On2jancW1zHfnfEOD9FfH1NvheL46em6URJdTlYjPq9vKW2Vrd3w7SrvLr014",
+	"7FKwkvPXrgc6kGQDgygqStzW8Na42qtU7d8UV6q5X7tx2UgeULaxlu0bY7m6Jn1iIe6+v+qItGQVK7IR",
+	"ty41A95iY6nUHRFtn2nfxsjsVEaSVMkrjvzdrl0NopaJ8LFuz39Yd2sH5pFb3L1povOgxtiDPThhC5q1",
+	"++NOaB5z7bA5rt3s/hSwbF3Cd7Fx5/QGLDaIxBYY7sMjZInDwA5dNV3xU+Cuvr4/D1ZRQ9uOrMKul/4N",
+	"/ikOMTatebj27kLvq8O0jgpw8zwTWu9u9x9yc2xPGus5cQTNHZQV725o4+xP2+5S/nNVvVXW3js1+WX+",
+	"bwAAAP//f8VLflsnAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"go.infratographer.com/identity-api/internal/crdbx"
 	"go.infratographer.com/x/gidx"
 )
 
@@ -94,6 +95,15 @@ type OAuthClient struct {
 	Secret *string `json:"secret,omitempty"`
 }
 
+// Pagination collection response pagination
+type Pagination struct {
+	// Limit the limit used for the collection response
+	Limit int `json:"limit"`
+
+	// Next the cursor for the next page
+	Next *crdbx.Cursor `json:"next,omitempty"`
+}
+
 // User defines model for User.
 type User struct {
 	// Email Email of the user
@@ -112,6 +122,32 @@ type User struct {
 	Subject string `json:"sub"`
 }
 
+// OwnerID defines model for ownerID.
+type OwnerID = gidx.PrefixedID
+
+// PageCursor defines model for pageCursor.
+type PageCursor = crdbx.Cursor
+
+// PageLimit defines model for pageLimit.
+type PageLimit = int
+
+// IssuerCollection defines model for IssuerCollection.
+type IssuerCollection struct {
+	Issuers []Issuer `json:"issuers"`
+
+	// Pagination collection response pagination
+	Pagination Pagination `json:"pagination"`
+}
+
+// GetOwnerIssuersParams defines parameters for GetOwnerIssuers.
+type GetOwnerIssuersParams struct {
+	// Cursor the cursor to the results to return
+	Cursor *PageCursor `form:"cursor,omitempty" json:"cursor,omitempty" query:"cursor"`
+
+	// Limit limits the response collections
+	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty" query:"limit"`
+}
+
 // UpdateIssuerJSONRequestBody defines body for UpdateIssuer for application/json ContentType.
 type UpdateIssuerJSONRequestBody = IssuerUpdate
 
@@ -124,26 +160,33 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xYTW/bOBD9KwR3D7uAYrntzbc0LgJ1t7tBnKCHNChoaWwzlUgth3JiGPrviyGlSLZk",
-	"O0mDoml7sk1TnI83781Qax7rLNcKlEU+WnOMF5AJ9/XEgLAQIRZg6HdudA7GSnD/xqmQ2edM5LlUc7ci",
-	"kkRaqZVIzzZ22lUOfMTRGqnmvAx4AhgbmdNePuIn7/5mcJcbQJRaIauOZFZ/AcWcGWRWM20XYKrfPKhP",
-	"1dMbiC2denP7BT8XRpLJTQvvP/41YZfnUfNU5UvA747m+kiJDKpttKsMuF/ZPueYLYpMqCMDIhHTFBht",
-	"YzNtmF0Akz5RQTfeXqcuz6OtRwfsQ4GWZcLGC7f8iUvET9zHzJYiLYBJxaSKdUYZev/xAg/E5OIpA27g",
-	"v0IaSPjoygfnvWpl7boMKsT/PS7s4iSVoGwXdlEkElTcl53qH2R2ISyzC4ksdqewWChGHgBaHnBpIesv",
-	"jGpBGCNWT4XBm+zC0JcEinkMKVg4B8y1QugGjEUcA2KPG+mtWCGzpoBBY26qdQpCdezVx5DJF0MpmXTD",
-	"jsZMz/YV/GYBRuN6odo1l8nd4MzATN5BEo1/MfcRzJUJD3bQN9iunqbQLvNEWPil4C+5DsqAP1GWT41Q",
-	"1sVa78FHaXCfBjhX2OvBkHl/mGP518pAP2Tj5hcJz8kOeQ84QmzA7nC25evE7zvUINpcu88ukeoS+7Qb",
-	"MiHTrvF3tFwLZoH91bU/xWTveRIs+9pYY8irxV5nt2x6vuyE7h8i14HYsZju82lSOHW459kDvKoe6QeU",
-	"UuCNXjtSSTXTXfsTiAsj7YpdOAWbgFnKGNgfk4vJn+yDUGIOGZXS8VnEJDKh3DfyMaM/idmTiwmLtZrJ",
-	"eWEEHYtuSJA2hd0GNo/mAV+CQe/ScDAcvKKE6RyUyCUf8TeD4eAND3gu7MIBG4pchstXoR+BMFz7L9G4",
-	"9CHSoEPfqG6dT1HiCEbrbXWhI43IwIJBPrrqRyduMV/SMrlRU2bEa9O8DQLNSkF1xeiKz4H6La/pKD+m",
-	"uXBfD4eujWllK00UeZ7K2IUW3iA5u25Z+93AjI/4b2Fz4wmr6064NQW62tiqCT/AzYqUtbZRLWWZMKv7",
-	"RLpy8ClqtEpQf71qS7hv0HMvWJuAnIL9ydFoh/8kKE7BIiNum8zZZ2KqC9sg07SDwW54yuCeUb69Y7iW",
-	"yQO4FNVzxF7g/CDtT6bpqDqzFz+nXT8cj8xBHlXZuZXWz1NzuQTFonEbNZ/t/Xzye96uHAMehcrcjQov",
-	"GZK6Sz8FCsejBofpak/uc5p6u9n3t4+nUaLwN5dvlH/3fuKtTlbPnPrq/lVuDiTkcPmdwu49biHfj3lL",
-	"IPWtcvroPqNxWc8gblDW2MPK7rumQ42OjqaqyI1eShqLnCRs9L9CJa7Keuql8uz7L5puYr5x5Xx19/UR",
-	"tAah+BGttlNJVe89VEmPURhdl1LsHq0VR6ofonTazH8ZetMqmAfqDd0DMVzTR3W92dX66fr8kMbfXLN7",
-	"KsDbeSEN372geNax2b2DaGNCvx0iZfl/AAAA//9Kt5giQRoAAA==",
+	"H4sIAAAAAAAC/+xZX2/bOBL/KgTvHu4A2XLapwtwD21SBO6m26BOtkXboKCpscVWIlWSSmwE+u6LIfXX",
+	"kh0nzQabbp9siaP5/5sZkjeUqzRTEqQ19PCGZkyzFCxo96SuJejpMf6NwHAtMiuUpIdUREQtCCMajMo1",
+	"B+IoaUAFrmbMxjSgkqVAD2smAdXwPRcaInpodQ4BNTyGlCF3u86Q1Fgt5JIGdDVaqlH5cimi1fhMw0Ks",
+	"IHJ86tWRSDOlrVfcxkisxkIuNLNqqVkWgx5zlYarEJnQoii/LTV7W2pWBDRjSzjKtVG6b6yNgXC3Rqwi",
+	"+KTB5Ik1+KjB5lpWln/PQa8b0/1XdF9LuY7mq/FR9dGdzRQRSCvsesQyEQppQUuWhI5rabtimRhxFcES",
+	"5AhWVrORZUsXa696rXNROuVUpML2fZLga1M5I1PSAOEqSYAjgdniD/fVkDtQ2SVouq+SnlGBSlbi3frU",
+	"mBz0Ua0IvuNKWpDOBpZlieAMV8Kvxi83umRaZaCt8KyEY+X/Wkjdn39rWNBD+q+wAU3ovzehF40WlDYx",
+	"rdm6zC0hWaXOLh5nDaU3rcLLp1qdDrvLWpiafwVeeqQbKdaKC4K2YoSUpVxU60gDs1Aa0XMGT5hIv6Qs",
+	"y4T0kWBRJJAlS846lN387mlz9OqUwCrTYAzmCSlZEqu+gSROjIOVsjHo8pn2rAzo1+tv5kuuRT8zX7//",
+	"bUYu3k2br7pYK1MRyZCqqJJzk88LEucpkyMNLGLzBAiSkQUWgRhKL/ZkFAEdVOri3XTj0zF5kxtLUmZ5",
+	"7F5/xhB/pt5mcsWSHIiQREiuUvTQ6/fn5habnD0beeOWvFYtr10WQRnxty9yGx8lokRIN+wsjwRIPuSd",
+	"cgVLALPExsIQ7rgQziRBDcAg1Gvs9By1CZP7hMGL7IdhyAlo8zEkYOFdWTL6BpucczBmQI3kmq0Nwb41",
+	"bsTNlUqA9cFasUGRTwZSIuqbPT3GkrEj4bsJ2O3OA737F3L3R66IqsbZg2+wmT1Nol1kEbPwq4I/5Two",
+	"AnrPsnyimbTO1orG3KkGD9UApwp5Np4Qrw9xKP/RMjAcsuPmCQvP0ZbyHlADXIPdomxL15mnu61BtLFW",
+	"exdBddaZ3bqyWnNVPQO3hrNgI2rJ8CSNmeOWSG4gajpbnzkNKKxYmiVADw8mwebs7EZnHWGvOUAHw8ru",
+	"3MtUkpAQ9e7wpx8/xPH8w0vzcXYQz9P/TdjJH+vT98m30/Pp/7eF/1G2MRuR8169HCgwF2ao7ULKRNL3",
+	"yyt8XfW63AwXht3oQHkPgw0xNIE0gnyh36nshsx6azKMut+xLt5iu8nnu3Sa5c7vdVLtoVX5yTAW0QVe",
+	"6KULuZAL1Zc/A55rYdfk3DWfGegrwYH8Z3Y++y95wyRbQopV4MXZlAhDmHT/UMcUF7Eoz85nhCu5EMtc",
+	"O9waN98J61CwRUCXNQ3oFWjjVZqMJ+MDdJjKQLJM0EP6fDwZP3cbNxu7wIaY2FcHoZ9eTXjj/0yPC28i",
+	"zqju+CUDr9M0crUR37cbQ9A5rvk0HB3eKtoDpzOV6Ac7nimKy41N+bPJ5E778F075I0BfmC/O/Oz9yJP",
+	"SIsMcylNmTs88DxcOngXNW3GHTN8andfP1stfa/pBuQE7D88Gm3z7xWKE7CGILZ16uQTNle5bSLTdPLx",
+	"9vAUQY2o8nAjvBHRHliaViPgzsD5PZDnjINtyXMwfq52/XQ40rfiqPTOtbB+FF6KK5BketyO2rQ8eNqF",
+	"J0/zcu0QcKeoLN2U95RDUnXp+4TC4aiJw3y9w/cZblj63vcbx/tBIvebzkfyvztaeqmi9QO7vtw6b4yY",
+	"qHDxNw2717gV+eGYtwqku4wx4U15KVNUM4gblJUZQGX/mPC2RoesMSsyra4EjkWuJHT6Xy6jx7ou+suS",
+	"pu+YR86cH+6+3oLWIMTv0Gp7mdS6MNk6Ljna1k1GJ42GbG1IQlXf1t1K2rrN25PaX3Ntq+9DDGq6sHfp",
+	"NDTjeKOxMjs7iCuLg+V5BwrvUp1VBUPuPq2qtZA/BezaVfNp1OoW2Pas1biHNuEN/pRbw224ujD7DU3N",
+	"EcVABng5T2RYcoc7D7rlcOc37Zjgs4tIUfwZAAD//w7iQP4mIQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -139,6 +139,23 @@ type IssuerCollection struct {
 	Pagination Pagination `json:"pagination"`
 }
 
+// OAuthClientCollection defines model for OAuthClientCollection.
+type OAuthClientCollection struct {
+	Clients []OAuthClient `json:"clients"`
+
+	// Pagination collection response pagination
+	Pagination Pagination `json:"pagination"`
+}
+
+// GetOwnerOAuthClientsParams defines parameters for GetOwnerOAuthClients.
+type GetOwnerOAuthClientsParams struct {
+	// Cursor the cursor to the results to return
+	Cursor *PageCursor `form:"cursor,omitempty" json:"cursor,omitempty" query:"cursor"`
+
+	// Limit limits the response collections
+	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty" query:"limit"`
+}
+
 // GetOwnerIssuersParams defines parameters for GetOwnerIssuers.
 type GetOwnerIssuersParams struct {
 	// Cursor the cursor to the results to return
@@ -160,33 +177,34 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZX2/bOBL/KgTvHu4A2XLapwtwD21SBO6m26BOtkXboKCpscVWIlWSSmwE+u6LIfXX",
-	"kh0nzQabbp9siaP5/5sZkjeUqzRTEqQ19PCGZkyzFCxo96SuJejpMf6NwHAtMiuUpIdUREQtCCMajMo1",
-	"B+IoaUAFrmbMxjSgkqVAD2smAdXwPRcaInpodQ4BNTyGlCF3u86Q1Fgt5JIGdDVaqlH5cimi1fhMw0Ks",
-	"IHJ86tWRSDOlrVfcxkisxkIuNLNqqVkWgx5zlYarEJnQoii/LTV7W2pWBDRjSzjKtVG6b6yNgXC3Rqwi",
-	"+KTB5Ik1+KjB5lpWln/PQa8b0/1XdF9LuY7mq/FR9dGdzRQRSCvsesQyEQppQUuWhI5rabtimRhxFcES",
-	"5AhWVrORZUsXa696rXNROuVUpML2fZLga1M5I1PSAOEqSYAjgdniD/fVkDtQ2SVouq+SnlGBSlbi3frU",
-	"mBz0Ua0IvuNKWpDOBpZlieAMV8Kvxi83umRaZaCt8KyEY+X/Wkjdn39rWNBD+q+wAU3ovzehF40WlDYx",
-	"rdm6zC0hWaXOLh5nDaU3rcLLp1qdDrvLWpiafwVeeqQbKdaKC4K2YoSUpVxU60gDs1Aa0XMGT5hIv6Qs",
-	"y4T0kWBRJJAlS846lN387mlz9OqUwCrTYAzmCSlZEqu+gSROjIOVsjHo8pn2rAzo1+tv5kuuRT8zX7//",
-	"bUYu3k2br7pYK1MRyZCqqJJzk88LEucpkyMNLGLzBAiSkQUWgRhKL/ZkFAEdVOri3XTj0zF5kxtLUmZ5",
-	"7F5/xhB/pt5mcsWSHIiQREiuUvTQ6/fn5habnD0beeOWvFYtr10WQRnxty9yGx8lokRIN+wsjwRIPuSd",
-	"cgVLALPExsIQ7rgQziRBDcAg1Gvs9By1CZP7hMGL7IdhyAlo8zEkYOFdWTL6BpucczBmQI3kmq0Nwb41",
-	"bsTNlUqA9cFasUGRTwZSIuqbPT3GkrEj4bsJ2O3OA737F3L3R66IqsbZg2+wmT1Nol1kEbPwq4I/5Two",
-	"AnrPsnyimbTO1orG3KkGD9UApwp5Np4Qrw9xKP/RMjAcsuPmCQvP0ZbyHlADXIPdomxL15mnu61BtLFW",
-	"exdBddaZ3bqyWnNVPQO3hrNgI2rJ8CSNmeOWSG4gajpbnzkNKKxYmiVADw8mwebs7EZnHWGvOUAHw8ru",
-	"3MtUkpAQ9e7wpx8/xPH8w0vzcXYQz9P/TdjJH+vT98m30/Pp/7eF/1G2MRuR8169HCgwF2ao7ULKRNL3",
-	"yyt8XfW63AwXht3oQHkPgw0xNIE0gnyh36nshsx6azKMut+xLt5iu8nnu3Sa5c7vdVLtoVX5yTAW0QVe",
-	"6KULuZAL1Zc/A55rYdfk3DWfGegrwYH8Z3Y++y95wyRbQopV4MXZlAhDmHT/UMcUF7Eoz85nhCu5EMtc",
-	"O9waN98J61CwRUCXNQ3oFWjjVZqMJ+MDdJjKQLJM0EP6fDwZP3cbNxu7wIaY2FcHoZ9eTXjj/0yPC28i",
-	"zqju+CUDr9M0crUR37cbQ9A5rvk0HB3eKtoDpzOV6Ac7nimKy41N+bPJ5E778F075I0BfmC/O/Oz9yJP",
-	"SIsMcylNmTs88DxcOngXNW3GHTN8andfP1stfa/pBuQE7D88Gm3z7xWKE7CGILZ16uQTNle5bSLTdPLx",
-	"9vAUQY2o8nAjvBHRHliaViPgzsD5PZDnjINtyXMwfq52/XQ40rfiqPTOtbB+FF6KK5BketyO2rQ8eNqF",
-	"J0/zcu0QcKeoLN2U95RDUnXp+4TC4aiJw3y9w/cZblj63vcbx/tBIvebzkfyvztaeqmi9QO7vtw6b4yY",
-	"qHDxNw2717gV+eGYtwqku4wx4U15KVNUM4gblJUZQGX/mPC2RoesMSsyra4EjkWuJHT6Xy6jx7ou+suS",
-	"pu+YR86cH+6+3oLWIMTv0Gp7mdS6MNk6Ljna1k1GJ42GbG1IQlXf1t1K2rrN25PaX3Ntq+9DDGq6sHfp",
-	"NDTjeKOxMjs7iCuLg+V5BwrvUp1VBUPuPq2qtZA/BezaVfNp1OoW2Pas1biHNuEN/pRbw224ujD7DU3N",
-	"EcVABng5T2RYcoc7D7rlcOc37Zjgs4tIUfwZAAD//w7iQP4mIQAA",
+	"H4sIAAAAAAAC/+xZX2/bNhD/KgS3hw2QLad9WoA9tE4RuEvXoE7Wom1Q0NLZYiuRKkklNgJ99+FIypIs",
+	"2XHSNFi6PtmSTvf/d3+oaxrJLJcChNH08JrmTLEMDCh7Ja8EqMkR/o1BR4rnhktBDymPiZwTRhRoWagI",
+	"iKWkAeX4NGcmoQEVLAN6uGYSUAVfC64gpodGFRBQHSWQMeRuVjmSaqO4WNCALgcLOfA3FzxeDk8VzPkS",
+	"Ystn/XTAs1wq4xQ3CRLLIRdzxYxcKJYnoIaRzMJliExoWfp3vWavvWZlQHO2gHGhtFRdY00CJLLPiJEE",
+	"rxToIjUaLxWYQonK8q8FqFVtunuL7mtppOLZcjiuXrq1mTwGYbhZDVjOQy4MKMHS0HL1tkuW80EkY1iA",
+	"GMDSKDYwbGFj7VRf61x6p5zwjJuuT1K8rStn5FJoIJFMU4iQQG/xh32rzx2o7AIU3VdJx6hEJSvx9vlE",
+	"6wLUeK0I3oukMCCsDSzPUx4xfBJ+1u5xrUuuZA7KcMeKW1bur4HM/vlVwZwe0l/CGjShe1+HTjRa4G1i",
+	"SrGVzy0uWKXOLh6nNaUzrcLLh7U6LXYXa2Fy9hki75F2pFgjLgjailEZ0NfPCpOMUw7C3IvLIstqf5c1",
+	"5H83v1U6fbPfrLJk7NkhvZeOyo0VMAM+BXr8wnj2KWN5zoXLYxbHHBmz9LRF2a4OHZ3GL04ILHMFWiPK",
+	"iGdJjPwCglgxtihJk4Dy17Rja0A/X33RnwrFu7h++favKTl/M6nfalcqD2QkQ6qygvYmn2ckKTImBgpY",
+	"zGYpECQjcyyhCfgc7MgoA9qr1PmbycarQ/Kq0IZkzESJvf0RAfKROpvJJUsLIFwQLiKZoYdevj3TN9hk",
+	"7dnIHvvIadXw2kUZ+Ig3M7gTdlbEHETU5x3/BAsoM8QkXBOXqCRigqAGoLFQrmHUcdQmWO4SBieyG4Y+",
+	"J6DNR5CCgTe+4HYN1kUUgdY9aqRXbKUJdv1hLW4mZQqsC9mKDYp8NJDicdfsyREWjh0J307A9mzTM/n8",
+	"RO7+yOVxNXZ04BtsZk+daOd5zAz8rOCPOQ/ag81tyvKxYsJYWysafasa3FcD3NjwZDjyowOxKP/WMtAf",
+	"sqP6CgvPeEt5D6iGSIHZomxD16mju6lBNLG29i6C6rQ1wbVlNaar9QbRGNGCjail/XsIZo59RAoNcd3Z",
+	"usxpQGHJsjwFengwCjY3D7t4qBh7zQE6GJZm5yZYSUJC1LvFn75/lySzd8/1++lBMsv+GLHjf1Ynb9Mv",
+	"J2eTP7eF/0GWwI3IOa9e9BSYc93XdiFjPO365QXernpdofsLw250oLz7wQbvm0BqQa7Q71R2Q+Z6setH",
+	"3d9YF2+wXRezXTpNC+v3dVLtoZV/pR+L6AIn9MKGnIu57MqfQlQoblbkzDafKahLHgH5bXo2/Z28YoIt",
+	"IMMq8Ox0QrgmTNh/qGOGD7EoT8+mJJJizheFsrjVdr7jxqJgi4A2axrQS1DaqTQajoYH6DCZg2A5p4f0",
+	"6XA0fGrXN5PYwIaY2JcHod/swmv3Z3JUOhNxRrWHVzk4nSaxrY14v9kYgtZh14f+6ESNot1ztlWJvrfD",
+	"rbK82DjSeDIa3Wol37UnbwzwPVvv1M3e8yIlDTLMpSxj9ujF8bDp0FyJMez2kOZDs/u62Wrhek07IMdg",
+	"/ufRaB1/3CUUx2A0QWyrzMonbCYLU0em7uTD7eEpgzWi/NFQeM3jPbA0qUbAnYFzO5DjjIOt59kbP1u7",
+	"fjgcqRtx5L1zxY0bhRf8EgSZHDWjNvHHdrvw5GierywCbhWVhZ3yHnNIqi59l1BYHNVxmK12+D7HhaXr",
+	"fbc43g0ShVs6H8j/9mjpuYxX9+x6vzpvjJiocPkfDbvTuBH5/pg3CqT9lKXDa/9JqwwbJ95bmxzStmpu",
+	"Jz36DKxJQrn+THUjaeMz1p7U7vvONmj2MVjThf3fD3qwJVndvTXiy5pEbHJvnRpyqXs82j13vWlysKKM",
+	"JLmSlxznTFtjWwNFIeKH+nr53VDYdcwDQ/GbxxlnQWOyjG4xu3Sg2fh+txOak8aHtR8ClZ1voH1DozN6",
+	"CxRb/W4HCm/T7mQFw8i+WrU/Ln4I2DXb0ONofg2w7dn8Cm0Bhj9+196Gq3O93xRan/n0ZICT80imT3ta",
+	"dq87nD0Qa8YEr21EyvLfAAAA//+5OvyFtSMAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -122,6 +122,9 @@ type User struct {
 	Subject string `json:"sub"`
 }
 
+// IssuerID defines model for issuerID.
+type IssuerID = gidx.PrefixedID
+
 // OwnerID defines model for ownerID.
 type OwnerID = gidx.PrefixedID
 
@@ -145,6 +148,22 @@ type OAuthClientCollection struct {
 
 	// Pagination collection response pagination
 	Pagination Pagination `json:"pagination"`
+}
+
+// UserCollection defines model for UserCollection.
+type UserCollection struct {
+	// Pagination collection response pagination
+	Pagination Pagination `json:"pagination"`
+	Users      []User     `json:"users"`
+}
+
+// GetIssuerUsersParams defines parameters for GetIssuerUsers.
+type GetIssuerUsersParams struct {
+	// Cursor the cursor to the results to return
+	Cursor *PageCursor `form:"cursor,omitempty" json:"cursor,omitempty" query:"cursor"`
+
+	// Limit limits the response collections
+	Limit *PageLimit `form:"limit,omitempty" json:"limit,omitempty" query:"limit"`
 }
 
 // GetOwnerOAuthClientsParams defines parameters for GetOwnerOAuthClients.
@@ -177,34 +196,35 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xZX2/bNhD/KgS3hw2QLad9WoA9tE4RuEvXoE7Wom1Q0NLZYiuRKkklNgJ99+FIypIs",
-	"2XHSNFi6PtmSTvf/d3+oaxrJLJcChNH08JrmTLEMDCh7Ja8EqMkR/o1BR4rnhktBDymPiZwTRhRoWagI",
-	"iKWkAeX4NGcmoQEVLAN6uGYSUAVfC64gpodGFRBQHSWQMeRuVjmSaqO4WNCALgcLOfA3FzxeDk8VzPkS",
-	"Ystn/XTAs1wq4xQ3CRLLIRdzxYxcKJYnoIaRzMJliExoWfp3vWavvWZlQHO2gHGhtFRdY00CJLLPiJEE",
-	"rxToIjUaLxWYQonK8q8FqFVtunuL7mtppOLZcjiuXrq1mTwGYbhZDVjOQy4MKMHS0HL1tkuW80EkY1iA",
-	"GMDSKDYwbGFj7VRf61x6p5zwjJuuT1K8rStn5FJoIJFMU4iQQG/xh32rzx2o7AIU3VdJx6hEJSvx9vlE",
-	"6wLUeK0I3oukMCCsDSzPUx4xfBJ+1u5xrUuuZA7KcMeKW1bur4HM/vlVwZwe0l/CGjShe1+HTjRa4G1i",
-	"SrGVzy0uWKXOLh6nNaUzrcLLh7U6LXYXa2Fy9hki75F2pFgjLgjailEZ0NfPCpOMUw7C3IvLIstqf5c1",
-	"5H83v1U6fbPfrLJk7NkhvZeOyo0VMAM+BXr8wnj2KWN5zoXLYxbHHBmz9LRF2a4OHZ3GL04ILHMFWiPK",
-	"iGdJjPwCglgxtihJk4Dy17Rja0A/X33RnwrFu7h++favKTl/M6nfalcqD2QkQ6qygvYmn2ckKTImBgpY",
-	"zGYpECQjcyyhCfgc7MgoA9qr1PmbycarQ/Kq0IZkzESJvf0RAfKROpvJJUsLIFwQLiKZoYdevj3TN9hk",
-	"7dnIHvvIadXw2kUZ+Ig3M7gTdlbEHETU5x3/BAsoM8QkXBOXqCRigqAGoLFQrmHUcdQmWO4SBieyG4Y+",
-	"J6DNR5CCgTe+4HYN1kUUgdY9aqRXbKUJdv1hLW4mZQqsC9mKDYp8NJDicdfsyREWjh0J307A9mzTM/n8",
-	"RO7+yOVxNXZ04BtsZk+daOd5zAz8rOCPOQ/ag81tyvKxYsJYWysafasa3FcD3NjwZDjyowOxKP/WMtAf",
-	"sqP6CgvPeEt5D6iGSIHZomxD16mju6lBNLG29i6C6rQ1wbVlNaar9QbRGNGCjail/XsIZo59RAoNcd3Z",
-	"usxpQGHJsjwFengwCjY3D7t4qBh7zQE6GJZm5yZYSUJC1LvFn75/lySzd8/1++lBMsv+GLHjf1Ynb9Mv",
-	"J2eTP7eF/0GWwI3IOa9e9BSYc93XdiFjPO365QXernpdofsLw250oLz7wQbvm0BqQa7Q71R2Q+Z6setH",
-	"3d9YF2+wXRezXTpNC+v3dVLtoZV/pR+L6AIn9MKGnIu57MqfQlQoblbkzDafKahLHgH5bXo2/Z28YoIt",
-	"IMMq8Ox0QrgmTNh/qGOGD7EoT8+mJJJizheFsrjVdr7jxqJgi4A2axrQS1DaqTQajoYH6DCZg2A5p4f0",
-	"6XA0fGrXN5PYwIaY2JcHod/swmv3Z3JUOhNxRrWHVzk4nSaxrY14v9kYgtZh14f+6ESNot1ztlWJvrfD",
-	"rbK82DjSeDIa3Wol37UnbwzwPVvv1M3e8yIlDTLMpSxj9ujF8bDp0FyJMez2kOZDs/u62Wrhek07IMdg",
-	"/ufRaB1/3CUUx2A0QWyrzMonbCYLU0em7uTD7eEpgzWi/NFQeM3jPbA0qUbAnYFzO5DjjIOt59kbP1u7",
-	"fjgcqRtx5L1zxY0bhRf8EgSZHDWjNvHHdrvw5GierywCbhWVhZ3yHnNIqi59l1BYHNVxmK12+D7HhaXr",
-	"fbc43g0ShVs6H8j/9mjpuYxX9+x6vzpvjJiocPkfDbvTuBH5/pg3CqT9lKXDa/9JqwwbJ95bmxzStmpu",
-	"Jz36DKxJQrn+THUjaeMz1p7U7vvONmj2MVjThf3fD3qwJVndvTXiy5pEbHJvnRpyqXs82j13vWlysKKM",
-	"JLmSlxznTFtjWwNFIeKH+nr53VDYdcwDQ/GbxxlnQWOyjG4xu3Sg2fh+txOak8aHtR8ClZ1voH1DozN6",
-	"CxRb/W4HCm/T7mQFw8i+WrU/Ln4I2DXb0ONofg2w7dn8Cm0Bhj9+196Gq3O93xRan/n0ZICT80imT3ta",
-	"dq87nD0Qa8YEr21EyvLfAAAA//+5OvyFtSMAAA==",
+	"H4sIAAAAAAAC/+xZ3W7bOhJ+FYK7F7uAbDnnXG3uWrsI3G232ThBirZBQUtji61EqiSV2Bvo3RdDSpZk",
+	"yYqdpEHS0yvL0nA4f9/wI3lLA5mkUoAwmh7f0pQploABZf9xrTNQ0wk+h6ADxVPDpaDHlIdELggTxIlQ",
+	"j3J8nTITUY8KloAVoh5V8CPjCkJ6bFQGHtVBBAlDjWadopQ2iosl9ehqsJSD4uWSh6vhqYIFX0E4ndS/",
+	"DniSSmWctSZCYTnkYqGYkUvF0gjUMJCJv/JRCc3zYmxh1LT0KfeovBG97hEFWmYqAGIlu70slTw/Vz8U",
+	"luUeTdkSxpnSUrWdNRGQwH4jRhL8p0BnsdH4V4HJlCg9/5GBWleuu1F0X08DFc5Xw3E56GA3eQjCcLMe",
+	"sJT7XBhQgsW+1Vr4LlnKB4EMYQliACuj2MCwpa1lZ/rG5rwIyjuecNOOSYyvdRmMVAoNJJBxDAEK6B3x",
+	"sKO6woHGLkHRfY10inI0spzefnfFO94Ygu8CKQwI6wNL05gHDL/437T7XNmSKpmCMhxq2HaPBhL78HcF",
+	"C3pM/+ZXTcF347XvpkYPCp+YUmxd1BYXrDSnT8dpJelcK/HyeWNOQ93VZjI5/wZBEZFmplgtLwjaUlHu",
+	"0Q+vMhONYw7CPErIAqtq/5DV5v9pcSttenDcrLFkXKjLPXqhH6nS7uenRzN9SH2iue0ob0XLqXxwrJwa",
+	"lCtmR+PGCpiBAiYdtcN48jVhacqFwzoLQ44KWXzakGx20JYt4zfvCKxSBVpjJyKFSmLkdxDETmMbtzQR",
+	"qOI/bfno0W833/XXTPF273t7+e8ZuTibVqOa3bxodiiGUnnZ/rb1vCJRljAxUMBCNo+BoBhZ4DITQUUc",
+	"Wv52GnVxNt0aOiTvM21IwkwQ2ddfsIl8oc5ncs3iDAgXhItAJhiht5fn+g6frD9bNWM/OatqUbvKvSLj",
+	"dZS30s6ykIMIuqJTfMFFhhliIq6JAzMJmCBoAWhcTDbV3wrUdkO5TxrclO00dAUBfZ5ADAbOikWp7bDO",
+	"ggC07jAjvmFrTZAZDavp5lLGwNptrVSDU74YSPGw7fZ0gg2jp+C32OnkDnb4G7n7I9fuP7rh621XT1Vo",
+	"F2nIDPzu4C+5Dprk75C2fKKYMNbXUkYf1IO7eoCjVn8MRwW9IhblD20D3SmbVP+w8Yx3tHePaggUmB3G",
+	"1mydObm7Fog61jbRRVCdNthfc64aq9rssmrUzNvKWty9V8PKsZ+Ql4XVytZWTj0KK5akMdDjo5G3vTuz",
+	"mzMV4lpzhAGGlendLZczoSDa3dBP2eV///XpYxTNP77Wn2ZH0SdxFgf8aMRO4v+9u4y/7yqBJ9ksb2XP",
+	"Rfaqo8lYWt3CDySMx+3YvMHX5XqHJLmr8PoRgvM9Dj54FwupJnLNvtfYroOj3cj7D/bGO3zX2bzPpllm",
+	"474prD2sKoZ04xFD4Ca9sinnYiHb888gyBQ3a3JuF6AZqGseAPnH7Hz2T/KeCbaEBDvBq9Mp4ZowYZ/Q",
+	"xgQ/YmOenc9IIMWCLzNlsastx+PGImHHBE3V1KPXoLQzaTQcDY/sCV0KgqWcHtM/h6Phn3brZiKbWB8L",
+	"+/rIL3bA/q17mE5y5yLyVHzCurU2TUPbH/F9fXHwGoeen7uzE9Qad8cZYDn1ox0C5vnV1tHPH6PRQXvw",
+	"vr3yFonv2PHOHP9eZDGpiWEtJQmzR1ROhy2H+tEBpt0eZn2ur8COXy3detNMyAmYv3g2GsdE90nFCRhN",
+	"ENsqsfMTNpeZqTJTrebD3enJvQ2iiiM0/5aHe2BpWtLA3sS5fZDTjOS20Pmz7w2eEY7UnTgqonPDjaPD",
+	"S34Ngkwn9axNi+PNPjw5mddri4CDsrK0TO8lp6Rcpe+TCoujKg/zdU/sU9y0tKPvNo/3g0TmNp5PFH97",
+	"vPRahutHDn2xfd6imGhw/kzT7iyuZb475zsapL85pu6H48Xm6LlREl1OVSI+r24r75St3fHtKe0uv3bh",
+	"sUvBRs7fuh7oQJINDKKoKHFbw71xtVep2r8trlRzv3bjspM8oGxjLTs0xnJzTfrMQtx9f9URackqVmQj",
+	"bl1qBrzFxlKpOyLaPtO+i5HZqYwkqZLXHPm7XbsaRC0T4VPdnv+07tYOzBO3uAfTROdBjbEHB3DCFjRr",
+	"98e90JzWLnZ/CVS27uC7yLhzegcUGzyiB4WH0AhZwjCwQzc9V/wSsKsv7y+DVNTAtiepsMulf4s/xRnG",
+	"Llzh0rsPu6/O0joqwM3zQli9u9x/zL2xPWis58Txs6s8z/P/BwAA//8OF7IsFScAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
This adds the following endpoints to list resources.

- `GET /api/v1/owners/{ownerID}/issuers` Lists issuers for an owner. Checks users access to `iam_issuer_list`
- `GET /api/v1/owners/{ownerID}/clients` Lists OAuth clients for an owner. Checks user access to `iam_oauthclient_list`
- `GET /api/v1/issuers/{issuerID}/users` Lists tracked users for an issuer. Checks user access to `iam_issuer_get`
