### PR TITLE
Custom claim mapping for influencing PrefixedID generation

### DIFF
--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -285,7 +285,7 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf("unable to populate user info: %s", err))
 	}
 
-	if subOverride, ok := mappedClaims.ToMapClaims()["prefixedid:sub"]; ok && subOverride != nil {
+	if subOverride, ok := mappedClaims.ToMapClaims()["identity-api.infratographer.com/sub"]; ok && subOverride != nil && subOverride.(string) != "" {
 		issHash := sha256.Sum256([]byte(userInfo.Issuer))
 
 		digest := base64.RawURLEncoding.EncodeToString(issHash[:])
@@ -317,7 +317,7 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 	newClaims.Issuer = s.config.GetAccessTokenIssuer(ctx)
 
 	for k, v := range mappedClaims.ToMapClaims() {
-		if k != "prefixedid:sub" {
+		if k != "identity-api.infratographer.com/sub" {
 			newClaims.Add(k, v)
 		}
 	}

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -3,6 +3,8 @@ package rfc8693
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -19,6 +21,7 @@ import (
 	"go.infratographer.com/identity-api/internal/fositex"
 	"go.infratographer.com/identity-api/internal/storage"
 	"go.infratographer.com/identity-api/internal/types"
+	"go.infratographer.com/x/gidx"
 )
 
 const (
@@ -282,6 +285,20 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf("unable to populate user info: %s", err))
 	}
 
+	if subOverride, ok := mappedClaims.ToMapClaims()["prefixedid:sub"]; ok && subOverride != nil {
+		issHash := sha256.Sum256([]byte(userInfo.Issuer))
+
+		digest := base64.RawURLEncoding.EncodeToString(issHash[:])
+
+		customPrefixedID, err := gidx.Parse(fmt.Sprintf("%s-%s-%s", types.IdentityUserIDPrefix, digest, subOverride))
+
+		if err != nil {
+			return errorsx.WithStack(fosite.ErrServerError.WithHintf("could not parse overridden subject to prefixed id: %s", err))
+		}
+
+		userInfo.ID = customPrefixedID
+	}
+
 	userInfo, err = userInfoSvc.StoreUserInfo(dbCtx, userInfo)
 
 	if err != nil {
@@ -300,7 +317,9 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 	newClaims.Issuer = s.config.GetAccessTokenIssuer(ctx)
 
 	for k, v := range mappedClaims.ToMapClaims() {
-		newClaims.Add(k, v)
+		if k != "prefixedid:sub" {
+			newClaims.Add(k, v)
+		}
 	}
 
 	expiry := time.Now().Add(s.config.GetAccessTokenLifespan(ctx))

--- a/internal/storage/userinfo.go
+++ b/internal/storage/userinfo.go
@@ -286,9 +286,15 @@ func (s userInfoService) StoreUserInfo(ctx context.Context, userInfo types.UserI
 		userInfoCols.IssuerID,
 	}, ",")
 
-	newID, err := generateSubjectID(types.IdentityUserIDPrefix, userInfo.Issuer, userInfo.Subject)
-	if err != nil {
-		return types.UserInfo{}, err
+	var newID gidx.PrefixedID
+
+	if userInfo.ID.String() == "" {
+		newID, err = generateSubjectID(types.IdentityUserIDPrefix, userInfo.Issuer, userInfo.Subject)
+		if err != nil {
+			return types.UserInfo{}, err
+		}
+	} else {
+		newID = userInfo.ID
 	}
 
 	q := fmt.Sprintf(`INSERT INTO user_info (%[1]s) VALUES (


### PR DESCRIPTION
Allows issuers to be configured with a custom claim mapping (`prefixedid:sub`) which alters the behavior of PrefixedID generation. If set for an issuer, the PrefixedID format becomes `idntusr-<issuer url hash>-<evaluated CEL>`. This allows for the configurable generation of IDs that remain somewhat readable to users/systems, as opposed to the default behavior of irreversibly hashing issuer and subject together.