### PR TITLE
use echo response writer

### DIFF
--- a/internal/routes/exchange.go
+++ b/internal/routes/exchange.go
@@ -64,7 +64,7 @@ func (h *tokenHandler) Handle(c echo.Context) error {
 		setContextFromError(c, err)
 
 		h.logger.Errorf("Error occurred in NewAccessRequest: %+v", err)
-		h.provider.WriteAccessError(ctx, c.Response().Writer, accessRequest, err)
+		h.provider.WriteAccessError(ctx, c.Response(), accessRequest, err)
 
 		return nil
 	}
@@ -78,13 +78,13 @@ func (h *tokenHandler) Handle(c echo.Context) error {
 	response, err := h.provider.NewAccessResponse(ctx, accessRequest)
 	if err != nil {
 		h.logger.Errorf("Error occurred in NewAccessResponse: %+v", err)
-		h.provider.WriteAccessError(ctx, c.Response().Writer, accessRequest, err)
+		h.provider.WriteAccessError(ctx, c.Response(), accessRequest, err)
 
 		return nil
 	}
 
 	// All done, send the response.
-	h.provider.WriteAccessResponse(ctx, c.Response().Writer, accessRequest, response)
+	h.provider.WriteAccessResponse(ctx, c.Response(), accessRequest, response)
 
 	return nil
 }


### PR DESCRIPTION
This updates the response writer to use the echo wrapped response writer. This corrects an issue with echo middleware which report http response status codes which rely on the `Status` attribute on the echo.Response object.