### PR TITLE
Add claim conditions

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -97,6 +97,7 @@ func serve(ctx context.Context) {
 	}
 
 	mappingStrategy := rfc8693.NewClaimMappingStrategy(storageEngine)
+	conditionStrategy := rfc8693.NewClaimConditionStrategy(storageEngine)
 
 	issuerJWKSURIProvider := jwks.NewIssuerJWKSURIProvider(storageEngine)
 
@@ -107,6 +108,7 @@ func serve(ctx context.Context) {
 
 	oauth2Config.IssuerJWKSURIProvider = issuerJWKSURIProvider
 	oauth2Config.ClaimMappingStrategy = mappingStrategy
+	oauth2Config.ClaimConditionStrategy = conditionStrategy
 	oauth2Config.UserInfoStrategy = storageEngine
 
 	keyGetter := func(ctx context.Context) (any, error) {

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -175,7 +175,7 @@ func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestOb
 
 	var claimConditions *types.ClaimConditions
 
-	if updateOp.ClaimConditions != nil && *updateOp.ClaimConditions != "" {
+	if updateOp.ClaimConditions != nil {
 		claimConditions, err = types.NewClaimConditions(*updateOp.ClaimConditions)
 		if err != nil {
 			err = echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error parsing CEL expression: %w", err))

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -2,8 +2,10 @@ package httpsrv
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/labstack/echo/v4"
 	"go.infratographer.com/permissions-api/pkg/permissions"
 	"go.infratographer.com/x/gidx"
 
@@ -48,10 +50,7 @@ func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestOb
 	if createOp.ClaimConditions != nil {
 		cond, err := types.NewClaimConditions(*createOp.ClaimConditions)
 		if err != nil {
-			err = errorWithStatus{
-				status:  http.StatusBadRequest,
-				message: "error parsing CEL expression",
-			}
+			err = echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error parsing CEL expression: %w", err))
 
 			return nil, err
 		}
@@ -179,10 +178,7 @@ func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestOb
 	if updateOp.ClaimConditions != nil && *updateOp.ClaimConditions != "" {
 		claimConditions, err = types.NewClaimConditions(*updateOp.ClaimConditions)
 		if err != nil {
-			err = errorWithStatus{
-				status:  http.StatusBadRequest,
-				message: "error parsing CEL expression",
-			}
+			err = echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error parsing CEL expression: %w", err))
 
 			return nil, err
 		}

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -50,7 +50,7 @@ func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestOb
 	if createOp.ClaimConditions != nil {
 		cond, err := types.NewClaimConditions(*createOp.ClaimConditions)
 		if err != nil {
-			err = echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("error parsing CEL expression: %w", err))
+			err = echo.NewHTTPError(http.StatusBadRequest, err.Error())
 
 			return nil, err
 		}

--- a/internal/api/httpsrv/handler_issuer.go
+++ b/internal/api/httpsrv/handler_issuer.go
@@ -28,8 +28,9 @@ func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestOb
 	}
 
 	var (
-		claimsMapping types.ClaimsMapping
-		err           error
+		claimsMapping   types.ClaimsMapping
+		claimConditions *types.ClaimConditions
+		err             error
 	)
 
 	if createOp.ClaimMappings != nil {
@@ -44,6 +45,20 @@ func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestOb
 		}
 	}
 
+	if createOp.ClaimConditions != nil {
+		cond, err := types.NewClaimConditions(*createOp.ClaimConditions)
+		if err != nil {
+			err = errorWithStatus{
+				status:  http.StatusBadRequest,
+				message: "error parsing CEL expression",
+			}
+
+			return nil, err
+		}
+
+		claimConditions = cond
+	}
+
 	id, err := gidx.NewID(types.IdentityIssuerIDPrefix)
 	if err != nil {
 		err = errorWithStatus{
@@ -55,12 +70,13 @@ func (h *apiHandler) CreateIssuer(ctx context.Context, req CreateIssuerRequestOb
 	}
 
 	issuerToCreate := types.Issuer{
-		OwnerID:       ownerID,
-		ID:            id,
-		Name:          createOp.Name,
-		URI:           createOp.URI,
-		JWKSURI:       createOp.JWKSURI,
-		ClaimMappings: claimsMapping,
+		OwnerID:         ownerID,
+		ID:              id,
+		Name:            createOp.Name,
+		URI:             createOp.URI,
+		JWKSURI:         createOp.JWKSURI,
+		ClaimMappings:   claimsMapping,
+		ClaimConditions: claimConditions,
 	}
 
 	issuer, err := h.engine.CreateIssuer(ctx, issuerToCreate)
@@ -158,11 +174,26 @@ func (h *apiHandler) UpdateIssuer(ctx context.Context, req UpdateIssuerRequestOb
 		}
 	}
 
+	var claimConditions *types.ClaimConditions
+
+	if updateOp.ClaimConditions != nil && *updateOp.ClaimConditions != "" {
+		claimConditions, err = types.NewClaimConditions(*updateOp.ClaimConditions)
+		if err != nil {
+			err = errorWithStatus{
+				status:  http.StatusBadRequest,
+				message: "error parsing CEL expression",
+			}
+
+			return nil, err
+		}
+	}
+
 	update := types.IssuerUpdate{
-		Name:          updateOp.Name,
-		URI:           updateOp.URI,
-		JWKSURI:       updateOp.JWKSURI,
-		ClaimMappings: claimsMapping,
+		Name:            updateOp.Name,
+		URI:             updateOp.URI,
+		JWKSURI:         updateOp.JWKSURI,
+		ClaimMappings:   claimsMapping,
+		ClaimConditions: claimConditions,
 	}
 
 	issuer, err := h.engine.UpdateIssuer(ctx, req.Id, update)

--- a/internal/fositex/config.go
+++ b/internal/fositex/config.go
@@ -65,6 +65,16 @@ type ClaimMappingStrategyProvider interface {
 	GetClaimMappingStrategy(ctx context.Context) ClaimMappingStrategy
 }
 
+// ClaimConditionStrategyProvider represents a provider of a claims condition eval strategy.
+type ClaimConditionStrategyProvider interface {
+	GetClaimConditionStrategy(ctx context.Context) ClaimConditionStrategy
+}
+
+// ClaimConditionStrategy represents a strategy for evaluating claims conditions.
+type ClaimConditionStrategy interface {
+	Eval(ctx context.Context, claims *jwt.JWTClaims) (bool, error)
+}
+
 // UserInfoStrategy persists user information in the storage backend.
 type UserInfoStrategy interface {
 	types.UserInfoService
@@ -87,6 +97,7 @@ type OAuth2Configurator interface {
 	SigningKeyProvider
 	SigningJWKSProvider
 	ClaimMappingStrategyProvider
+	ClaimConditionStrategyProvider
 	UserInfoStrategyProvider
 	GetIssuerJWKSURIProvider(ctx context.Context) IssuerJWKSURIProvider
 }
@@ -97,8 +108,9 @@ type OAuth2Config struct {
 	SigningKey  *jose.JSONWebKey
 	SigningJWKS *jose.JSONWebKeySet
 
-	ClaimMappingStrategy ClaimMappingStrategy
-	UserInfoStrategy     UserInfoStrategy
+	ClaimMappingStrategy   ClaimMappingStrategy
+	ClaimConditionStrategy ClaimConditionStrategy
+	UserInfoStrategy       UserInfoStrategy
 
 	IssuerJWKSURIProvider IssuerJWKSURIProvider
 	userInfoAudience      string
@@ -122,6 +134,11 @@ func (c *OAuth2Config) GetSigningJWKS(_ context.Context) *jose.JSONWebKeySet {
 // GetClaimMappingStrategy returns the config's claims mapping strategy.
 func (c *OAuth2Config) GetClaimMappingStrategy(_ context.Context) ClaimMappingStrategy {
 	return c.ClaimMappingStrategy
+}
+
+// GetClaimConditionStrategy returns the config's claim condition strategy.
+func (c *OAuth2Config) GetClaimConditionStrategy(_ context.Context) ClaimConditionStrategy {
+	return c.ClaimConditionStrategy
 }
 
 // GetUserInfoStrategy returns the config's user info store strategy.

--- a/internal/rfc8693/claims.go
+++ b/internal/rfc8693/claims.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 
 	"github.com/ory/fosite/token/jwt"
 
 	"go.infratographer.com/identity-api/internal/celutils"
+	"go.infratographer.com/identity-api/internal/fositex"
 	"go.infratographer.com/identity-api/internal/types"
 )
 
@@ -67,4 +69,53 @@ func (m ClaimMappingStrategy) MapClaims(ctx context.Context, claims *jwt.JWTClai
 	outputClaims.FromMap(outputMap)
 
 	return &outputClaims, nil
+}
+
+// ClaimConditionStrategy represents a strategy for evaluating claims conditions.
+type ClaimConditionStrategy struct {
+	issuerSvc types.IssuerService
+}
+
+// NewClaimConditionStrategy creates a ClaimConditionStrategy given an issuer service.
+func NewClaimConditionStrategy(issuerSvc types.IssuerService) ClaimConditionStrategy {
+	return ClaimConditionStrategy{
+		issuerSvc: issuerSvc,
+	}
+}
+
+// ClaimConditionStrategy implements fositex.ClaimConditionStrategy
+var _ fositex.ClaimConditionStrategy = (*ClaimConditionStrategy)(nil)
+
+// Eval evaluates the claims conditions for the given claims.
+func (c ClaimConditionStrategy) Eval(ctx context.Context, claims *jwt.JWTClaims) (bool, error) {
+	if claims.Issuer == "" {
+		return false, ErrorMissingIss
+	}
+
+	iss := claims.Issuer
+
+	issuer, err := c.issuerSvc.GetIssuerByURI(ctx, iss)
+	if err != nil {
+		return false, err
+	}
+
+	if issuer.ClaimConditions == nil || issuer.ClaimConditions.AST() == nil {
+		return true, nil
+	}
+
+	inputEnv := map[string]any{
+		celutils.CELVariableClaims: claims.ToMapClaims(),
+	}
+
+	res, err := celutils.Eval(issuer.ClaimConditions.AST(), inputEnv)
+	if err != nil {
+		return false, err
+	}
+
+	result, ok := res.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("%w: unexpected type for claim condition result: %T", ErrorInvalidClaimCondition, res.Value())
+	}
+
+	return result, nil
 }

--- a/internal/rfc8693/claims.go
+++ b/internal/rfc8693/claims.go
@@ -30,11 +30,11 @@ func NewClaimMappingStrategy(issuerSvc types.IssuerService) ClaimMappingStrategy
 // MapClaims consumes a set of JWT claims and produces a new set of mapped claims.
 func (m ClaimMappingStrategy) MapClaims(ctx context.Context, claims *jwt.JWTClaims) (jwt.JWTClaimsContainer, error) {
 	if claims.Subject == "" {
-		return nil, ErrorMissingSub
+		return nil, ErrMissingSub
 	}
 
 	if claims.Issuer == "" {
-		return nil, ErrorMissingIss
+		return nil, ErrMissingIss
 	}
 
 	iss := claims.Issuer
@@ -89,7 +89,7 @@ var _ fositex.ClaimConditionStrategy = (*ClaimConditionStrategy)(nil)
 // Eval evaluates the claims conditions for the given claims.
 func (c ClaimConditionStrategy) Eval(ctx context.Context, claims *jwt.JWTClaims) (bool, error) {
 	if claims.Issuer == "" {
-		return false, ErrorMissingIss
+		return false, ErrMissingIss
 	}
 
 	iss := claims.Issuer
@@ -114,7 +114,7 @@ func (c ClaimConditionStrategy) Eval(ctx context.Context, claims *jwt.JWTClaims)
 
 	result, ok := res.Value().(bool)
 	if !ok {
-		return false, fmt.Errorf("%w: unexpected type for claim condition result: %T", ErrorInvalidClaimCondition, res.Value())
+		return false, fmt.Errorf("%w: unexpected type for claim condition result: %T", ErrInvalidClaimCondition, res.Value())
 	}
 
 	return result, nil

--- a/internal/rfc8693/claims_test.go
+++ b/internal/rfc8693/claims_test.go
@@ -94,7 +94,7 @@ func TestClaimMappingEval(t *testing.T) {
 			},
 			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[jwt.JWTClaimsContainer]) {
 				assert.NotNil(t, result.Err)
-				assert.ErrorIs(t, result.Err, ErrorMissingSub)
+				assert.ErrorIs(t, result.Err, ErrMissingSub)
 			},
 		},
 		{
@@ -107,7 +107,7 @@ func TestClaimMappingEval(t *testing.T) {
 			},
 			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[jwt.JWTClaimsContainer]) {
 				assert.NotNil(t, result.Err)
-				assert.ErrorIs(t, result.Err, ErrorMissingIss)
+				assert.ErrorIs(t, result.Err, ErrMissingIss)
 			},
 		},
 		{

--- a/internal/rfc8693/claims_test.go
+++ b/internal/rfc8693/claims_test.go
@@ -134,3 +134,116 @@ func TestClaimMappingEval(t *testing.T) {
 
 	testingx.RunTests(context.Background(), t, testCases, runFn)
 }
+
+func TestClaimConditionsEval(t *testing.T) {
+	t.Parallel()
+
+	testServer, err := storage.InMemoryCRDB()
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "initialization failed")
+	}
+
+	err = testServer.Start()
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "initialization failed")
+	}
+
+	t.Cleanup(func() {
+		testServer.Stop()
+	})
+
+	config := crdbx.Config{
+		URI: testServer.PGURL().String(),
+	}
+
+	seedData := storage.SeedData{
+		Issuers: []storage.SeedIssuer{
+			{
+				OwnerID: gidx.MustNewID("testten"),
+				ID:      gidx.MustNewID("testiss"),
+				Name:    "no-conditions",
+				URI:     "https://no-conditions.com/",
+				JWKSURI: "https://no-conditions.com/.well-known/jwks.json",
+			},
+			{
+				OwnerID:         gidx.MustNewID("testten"),
+				ID:              gidx.MustNewID("testiss"),
+				Name:            "yes-conditions",
+				URI:             "https://yes-conditions.com/",
+				JWKSURI:         "https://yes-conditions.com/.well-known/jwks.json",
+				ClaimConditions: `has(claims.hello) && claims.hello == "world"`,
+			},
+		},
+	}
+
+	storageEngine, err := storage.NewEngine(config, storage.WithMigrations(), storage.WithSeedData(seedData))
+	if !assert.NoError(t, err) {
+		assert.FailNow(t, "initialization failed")
+	}
+
+	conditionStrategy := NewClaimConditionStrategy(storageEngine)
+
+	runFn := func(ctx context.Context, claims *jwt.JWTClaims) testingx.TestResult[bool] {
+		out, err := conditionStrategy.Eval(ctx, claims)
+
+		return testingx.TestResult[bool]{
+			Success: out,
+			Err:     err,
+		}
+	}
+
+	testCases := []testingx.TestCase[*jwt.JWTClaims, bool]{
+		{
+			Name: "SuccessWithNoConditions",
+			Input: &jwt.JWTClaims{
+				Subject: "foo",
+				Issuer:  "https://no-conditions.com/",
+			},
+			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[bool]) {
+				assert.Nil(t, result.Err)
+				assert.True(t, result.Success)
+			},
+		},
+		{
+			Name: "SuccessWithConditions",
+			Input: &jwt.JWTClaims{
+				Subject: "foo",
+				Issuer:  "https://yes-conditions.com/",
+				Extra: map[string]any{
+					"hello": "world",
+				},
+			},
+			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[bool]) {
+				assert.Nil(t, result.Err)
+				assert.True(t, result.Success)
+			},
+		},
+		{
+			Name: "MissingClaim",
+			Input: &jwt.JWTClaims{
+				Subject: "foo",
+				Issuer:  "https://yes-conditions.com/",
+			},
+			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[bool]) {
+				assert.Nil(t, result.Err)
+				assert.False(t, result.Success)
+			},
+		},
+		{
+			Name: "ConditionNotSatisfied",
+			Input: &jwt.JWTClaims{
+				Subject: "foo",
+				Issuer:  "https://yes-conditions.com/",
+				Extra: map[string]any{
+					"hello": "notworld",
+				},
+			},
+			CheckFn: func(_ context.Context, t *testing.T, result testingx.TestResult[bool]) {
+				assert.Nil(t, result.Err)
+				assert.False(t, result.Success)
+			},
+		},
+	}
+
+	testingx.RunTests(context.Background(), t, testCases, runFn)
+}

--- a/internal/rfc8693/errors.go
+++ b/internal/rfc8693/errors.go
@@ -1,6 +1,7 @@
 package rfc8693
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -14,6 +15,9 @@ var (
 	ErrorMissingIss = &ErrorMissingClaim{
 		claim: "iss",
 	}
+
+	// ErrorInvalidClaimCondition represents an error where the claim condition expression is invalid.
+	ErrorInvalidClaimCondition = errors.New("invalid claim condition expression")
 )
 
 // ErrorMissingClaim represents an error where a required claim is missing.

--- a/internal/rfc8693/errors.go
+++ b/internal/rfc8693/errors.go
@@ -6,25 +6,25 @@ import (
 )
 
 var (
-	// ErrorMissingSub represents an error where the 'sub' claim is missing from the input claims.
-	ErrorMissingSub = &ErrorMissingClaim{
+	// ErrMissingSub represents an error where the 'sub' claim is missing from the input claims.
+	ErrMissingSub = &ErrMissingClaim{
 		claim: "sub",
 	}
 
-	// ErrorMissingIss represents an error where the 'iss' claim is missing from the input claims.
-	ErrorMissingIss = &ErrorMissingClaim{
+	// ErrMissingIss represents an error where the 'iss' claim is missing from the input claims.
+	ErrMissingIss = &ErrMissingClaim{
 		claim: "iss",
 	}
 
-	// ErrorInvalidClaimCondition represents an error where the claim condition expression is invalid.
-	ErrorInvalidClaimCondition = errors.New("invalid claim condition expression")
+	// ErrInvalidClaimCondition represents an error where the claim condition expression is invalid.
+	ErrInvalidClaimCondition = errors.New("invalid claim condition expression")
 )
 
-// ErrorMissingClaim represents an error where a required claim is missing.
-type ErrorMissingClaim struct {
+// ErrMissingClaim represents an error where a required claim is missing.
+type ErrMissingClaim struct {
 	claim string
 }
 
-func (e *ErrorMissingClaim) Error() string {
+func (e *ErrMissingClaim) Error() string {
 	return fmt.Sprintf("missing required claim '%s'", e.claim)
 }

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -253,6 +253,15 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 		),
 	)
 
+	ok, err := s.config.GetClaimConditionStrategy(ctx).Eval(ctx, claims)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf("error evaluating claim conditions: %s", err))
+	}
+
+	if !ok {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("claim conditions not satisfied"))
+	}
+
 	mappedClaims, err := s.getMappedSubjectClaims(ctx, claims)
 	if err != nil {
 		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf("error mapping claims: %s", err))

--- a/internal/rfc8693/rfc8693.go
+++ b/internal/rfc8693/rfc8693.go
@@ -46,10 +46,8 @@ const (
 	instrumentationName = "go.infratographer.com/identity-api/internal/rfc6893"
 )
 
-var (
-	// ErrJWKSURIProviderNotDefined is returned when the issuer JWKS URI provider is not defined.
-	ErrJWKSURIProviderNotDefined = errors.New("no issuer JWKS URI provider defined")
-)
+// ErrJWKSURIProviderNotDefined is returned when the issuer JWKS URI provider is not defined.
+var ErrJWKSURIProviderNotDefined = errors.New("no issuer JWKS URI provider defined")
 
 func findMatchingKey(ctx context.Context, config fositex.OAuth2Configurator, token *jwt.Token) (interface{}, error) {
 	var claims jwt.JWTClaims
@@ -181,7 +179,6 @@ func (s *TokenExchangeHandler) getSubjectClaims(ctx context.Context, token strin
 	defer span.End()
 
 	validated, err := s.validateJWT(ctx, token)
-
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +289,6 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 		digest := base64.RawURLEncoding.EncodeToString(issHash[:])
 
 		customPrefixedID, err := gidx.Parse(fmt.Sprintf("%s-%s-%s", types.IdentityUserIDPrefix, digest, subOverride))
-
 		if err != nil {
 			return errorsx.WithStack(fosite.ErrServerError.WithHintf("could not parse overridden subject to prefixed id: %s", err))
 		}
@@ -301,14 +297,12 @@ func (s *TokenExchangeHandler) HandleTokenEndpointRequest(ctx context.Context, r
 	}
 
 	userInfo, err = userInfoSvc.StoreUserInfo(dbCtx, userInfo)
-
 	if err != nil {
 		rbErr := txManager.RollbackContext(dbCtx)
 		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHintf("unable to store user info: %s / rollback error: %s", err, rbErr))
 	}
 
 	err = txManager.CommitContext(dbCtx)
-
 	if err != nil {
 		return errorsx.WithStack(fosite.ErrServerError.WithHintf("could not commit user info: %s", err))
 	}

--- a/internal/storage/data.go
+++ b/internal/storage/data.go
@@ -11,12 +11,13 @@ import (
 
 // SeedIssuer represents the seed data for a single issuer.
 type SeedIssuer struct {
-	OwnerID       gidx.PrefixedID   `yaml:"ownerID"`
-	ID            gidx.PrefixedID   `yaml:"id"`
-	Name          string            `yaml:"name"`
-	URI           string            `yaml:"uri"`
-	JWKSURI       string            `yaml:"jwksURI"`
-	ClaimMappings map[string]string `yaml:"claimMappings"`
+	OwnerID         gidx.PrefixedID   `yaml:"ownerID"`
+	ID              gidx.PrefixedID   `yaml:"id"`
+	Name            string            `yaml:"name"`
+	URI             string            `yaml:"uri"`
+	JWKSURI         string            `yaml:"jwksURI"`
+	ClaimMappings   map[string]string `yaml:"claimMappings"`
+	ClaimConditions string            `yaml:"claimConditions"`
 }
 
 // SeedData represents the seed data for an identity-api instance on startup.

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -53,21 +53,31 @@ func buildIssuerFromSeed(seed SeedIssuer) (types.Issuer, error) {
 		return types.Issuer{}, err
 	}
 
+	claimConditions, err := types.NewClaimConditions(seed.ClaimConditions)
+	if err != nil {
+		return types.Issuer{}, err
+	}
+
 	out := types.Issuer{
-		OwnerID:       seed.OwnerID,
-		ID:            seed.ID,
-		Name:          seed.Name,
-		URI:           seed.URI,
-		JWKSURI:       seed.JWKSURI,
-		ClaimMappings: claimMappings,
+		OwnerID:         seed.OwnerID,
+		ID:              seed.ID,
+		Name:            seed.Name,
+		URI:             seed.URI,
+		JWKSURI:         seed.JWKSURI,
+		ClaimMappings:   claimMappings,
+		ClaimConditions: claimConditions,
 	}
 
 	return out, nil
 }
 
+// TestServerCRDBVersion is the version of CockroachDB that the test server is running
+// v23.1.28 is the last version under BSL
+const TestServerCRDBVersion = "v23.1.28"
+
 // InMemoryCRDB creates an in-memory CRDB test server.
 func InMemoryCRDB() (testserver.TestServer, error) {
-	ts, err := testserver.NewTestServer()
+	ts, err := testserver.NewTestServer(testserver.CustomVersionOpt(TestServerCRDBVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/engine.go
+++ b/internal/storage/engine.go
@@ -72,8 +72,8 @@ func buildIssuerFromSeed(seed SeedIssuer) (types.Issuer, error) {
 }
 
 // TestServerCRDBVersion is the version of CockroachDB that the test server is running
-// v23.1.28 is the last version under BSL
-const TestServerCRDBVersion = "v23.1.28"
+// v24.1.6 is the last version under BSL
+const TestServerCRDBVersion = "v24.1.6"
 
 // InMemoryCRDB creates an in-memory CRDB test server.
 func InMemoryCRDB() (testserver.TestServer, error) {

--- a/internal/storage/issuer.go
+++ b/internal/storage/issuer.go
@@ -287,9 +287,13 @@ func (s *issuerService) insertIssuer(ctx context.Context, iss types.Issuer) erro
 		return err
 	}
 
-	conditions, err := iss.ClaimConditions.MarshalJSON()
-	if err != nil {
-		return err
+	conditions := []byte{}
+
+	if iss.ClaimConditions != nil {
+		conditions, err = iss.ClaimConditions.MarshalJSON()
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = tx.ExecContext(

--- a/internal/storage/issuer.go
+++ b/internal/storage/issuer.go
@@ -14,19 +14,21 @@ import (
 )
 
 var issuerCols = struct {
-	OwnerID  string
-	ID       string
-	Name     string
-	URI      string
-	JWKSURI  string
-	Mappings string
+	OwnerID    string
+	ID         string
+	Name       string
+	URI        string
+	JWKSURI    string
+	Mappings   string
+	Conditions string
 }{
-	OwnerID:  "owner_id",
-	ID:       "id",
-	Name:     "name",
-	URI:      "uri",
-	JWKSURI:  "jwksuri",
-	Mappings: "mappings",
+	OwnerID:    "owner_id",
+	ID:         "id",
+	Name:       "name",
+	URI:        "uri",
+	JWKSURI:    "jwksuri",
+	Mappings:   "mappings",
+	Conditions: "conditions",
 }
 
 var (
@@ -37,6 +39,7 @@ var (
 		issuerCols.URI,
 		issuerCols.JWKSURI,
 		issuerCols.Mappings,
+		issuerCols.Conditions,
 	}
 	issuerColumnsStr = strings.Join(issuerColumns, ", ")
 )
@@ -225,11 +228,13 @@ type rowScanner interface {
 }
 
 func (s *issuerService) scanIssuer(row rowScanner) (*types.Issuer, error) {
-	var iss types.Issuer
+	var (
+		iss     types.Issuer
+		mapping sql.NullString
+		cond    sql.NullString
+	)
 
-	var mapping sql.NullString
-
-	err := row.Scan(&iss.OwnerID, &iss.ID, &iss.Name, &iss.URI, &iss.JWKSURI, &mapping)
+	err := row.Scan(&iss.OwnerID, &iss.ID, &iss.Name, &iss.URI, &iss.JWKSURI, &mapping, &cond)
 
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
@@ -240,6 +245,7 @@ func (s *issuerService) scanIssuer(row rowScanner) (*types.Issuer, error) {
 	}
 
 	c := types.ClaimsMapping{}
+	conditions := types.ClaimConditions{}
 
 	if mapping.Valid {
 		err = c.UnmarshalJSON([]byte(mapping.String))
@@ -248,6 +254,14 @@ func (s *issuerService) scanIssuer(row rowScanner) (*types.Issuer, error) {
 		}
 
 		iss.ClaimMappings = c
+	}
+
+	if cond.Valid {
+		if err = conditions.UnmarshalJSON([]byte(cond.String)); err != nil {
+			return nil, err
+		}
+
+		iss.ClaimConditions = &conditions
 	}
 
 	return &iss, nil
@@ -263,12 +277,17 @@ func (s *issuerService) insertIssuer(ctx context.Context, iss types.Issuer) erro
         INSERT INTO issuers (
             %s
         ) VALUES
-        ($1, $2, $3, $4, $5, $6);
+        ($1, $2, $3, $4, $5, $6, $7);
         `
 
 	q = fmt.Sprintf(q, issuerColumnsStr)
 
 	mappings, err := iss.ClaimMappings.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	conditions, err := iss.ClaimConditions.MarshalJSON()
 	if err != nil {
 		return err
 	}
@@ -282,6 +301,7 @@ func (s *issuerService) insertIssuer(ctx context.Context, iss types.Issuer) erro
 		iss.URI,
 		iss.JWKSURI,
 		string(mappings),
+		string(conditions),
 	)
 
 	return err

--- a/internal/storage/issuer_test.go
+++ b/internal/storage/issuer_test.go
@@ -29,6 +29,9 @@ func compareIssuers(t *testing.T, exp types.Issuer, obs types.Issuer) {
 	exp.ClaimMappings = nil
 	obs.ClaimMappings = nil
 
+	exp.ClaimConditions = nil
+	obs.ClaimConditions = nil
+
 	assert.Equal(t, exp, obs)
 	assert.Equal(t, expMappings, obsMappings)
 }
@@ -36,7 +39,7 @@ func compareIssuers(t *testing.T, exp types.Issuer, obs types.Issuer) {
 func TestIssuerService(t *testing.T) {
 	t.Parallel()
 
-	db, shutdown := testserver.NewDBForTest(t)
+	db, shutdown := testserver.NewDBForTest(t, testserver.CustomVersionOpt(TestServerCRDBVersion))
 
 	err := runMigrations(db)
 	if err != nil {

--- a/internal/storage/migrations/0006_claim_conditions.sql
+++ b/internal/storage/migrations/0006_claim_conditions.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE issuers ADD COLUMN conditions STRING;
+-- +goose Down
+ALTER TABLE issuers DROP COLUMN conditions;

--- a/internal/storage/oauth_client_test.go
+++ b/internal/storage/oauth_client_test.go
@@ -15,13 +15,15 @@ import (
 	"go.infratographer.com/identity-api/internal/types"
 )
 
-var _ types.OAuthClientManager = &oauthClientManager{}
-var _ fosite.ClientManager = &oauthClientManager{}
+var (
+	_ types.OAuthClientManager = &oauthClientManager{}
+	_ fosite.ClientManager     = &oauthClientManager{}
+)
 
 func TestOAuthClientManager(t *testing.T) {
 	t.Parallel()
 
-	db, shutdown := testserver.NewDBForTest(t)
+	db, shutdown := testserver.NewDBForTest(t, testserver.CustomVersionOpt(TestServerCRDBVersion))
 
 	err := runMigrations(db)
 	if err != nil {

--- a/internal/storage/query.go
+++ b/internal/storage/query.go
@@ -58,6 +58,17 @@ func issuerUpdateToColBindings(update types.IssuerUpdate) ([]colBinding, error) 
 		bindings = bindIfNotNil(bindings, issuerCols.Mappings, &mappingStr)
 	}
 
+	if update.ClaimConditions != nil {
+		condRepr, err := update.ClaimConditions.MarshalJSON()
+		if err != nil {
+			return nil, err
+		}
+
+		condStr := string(condRepr)
+
+		bindings = bindIfNotNil(bindings, issuerCols.Conditions, &condStr)
+	}
+
 	return bindings, nil
 }
 

--- a/internal/storage/userinfo_test.go
+++ b/internal/storage/userinfo_test.go
@@ -18,7 +18,7 @@ import (
 func TestUserInfoStore(t *testing.T) {
 	t.Parallel()
 
-	db, shutdown := testserver.NewDBForTest(t)
+	db, shutdown := testserver.NewDBForTest(t, testserver.CustomVersionOpt(TestServerCRDBVersion))
 
 	err := runMigrations(db)
 	if err != nil {

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -39,6 +39,9 @@ var (
 
 	// ErrGroupMemberNotFound is returned if the group member doesn't exist.
 	ErrGroupMemberNotFound = fmt.Errorf("%w: group member not found", ErrNotFound)
+
+	// ErrInvalidCEL is returned if the CEL expression is invalid.
+	ErrInvalidCEL = fmt.Errorf("%w: invalid CEL expression", ErrInvalidArgument)
 )
 
 // ErrorInvalidTokenRequest represents an error where an access token request failed.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -49,6 +49,10 @@ type Issuer struct {
 	JWKSURI string
 	// ClaimMappings represents a map of claims to a CEL expression that will be evaluated
 	ClaimMappings ClaimsMapping
+	// ClaimConditions A CEL expressions to restrict authentication to a subset of identities
+	// whose claims must match the expressions. By default all identities
+	// issued by the issuer are allowed to authenticate
+	ClaimConditions *ClaimConditions
 }
 
 // ToV1Issuer converts an issuer to an API issuer.
@@ -58,12 +62,28 @@ func (i Issuer) ToV1Issuer() (v1.Issuer, error) {
 		return v1.Issuer{}, err
 	}
 
+	claimConditions := ""
+
+	if i.ClaimConditions != nil {
+		ast := i.ClaimConditions.AST()
+
+		if ast != nil {
+			str, err := cel.AstToString(ast)
+			if err != nil {
+				return v1.Issuer{}, err
+			}
+
+			claimConditions = str
+		}
+	}
+
 	out := v1.Issuer{
-		ID:            i.ID,
-		Name:          i.Name,
-		URI:           i.URI,
-		JWKSURI:       i.JWKSURI,
-		ClaimMappings: claimsMappingRepr,
+		ID:              i.ID,
+		Name:            i.Name,
+		URI:             i.URI,
+		JWKSURI:         i.JWKSURI,
+		ClaimMappings:   claimsMappingRepr,
+		ClaimConditions: claimConditions,
 	}
 
 	return out, nil
@@ -71,10 +91,11 @@ func (i Issuer) ToV1Issuer() (v1.Issuer, error) {
 
 // IssuerUpdate represents an update operation on an issuer.
 type IssuerUpdate struct {
-	Name          *string
-	URI           *string
-	JWKSURI       *string
-	ClaimMappings ClaimsMapping
+	Name            *string
+	URI             *string
+	JWKSURI         *string
+	ClaimMappings   ClaimsMapping
+	ClaimConditions *ClaimConditions
 }
 
 // IssuerService represents a service for managing issuers.
@@ -201,6 +222,57 @@ func (i UserInfos) ToV1Users() ([]v1.User, error) {
 	}
 
 	return users, nil
+}
+
+// ClaimConditions is a CEL expression to evaluate the claims of a token
+type ClaimConditions struct {
+	ast *cel.Ast
+}
+
+// NewClaimConditions creates a ClaimConditions from the given CEL expression.
+func NewClaimConditions(expr string) (*ClaimConditions, error) {
+	ast, err := celutils.ParseCEL(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClaimConditions{ast: ast}, nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (c *ClaimConditions) MarshalJSON() ([]byte, error) {
+	if c.ast == nil {
+		return nil, nil
+	}
+
+	expr, err := cel.AstToCheckedExpr(c.ast)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := prototext.Marshal(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (c *ClaimConditions) UnmarshalJSON(data []byte) error {
+	var expr exprpb.CheckedExpr
+	if err := prototext.Unmarshal(data, &expr); err != nil {
+		return err
+	}
+
+	c.ast = cel.CheckedExprToAst(&expr)
+
+	return nil
+}
+
+// AST returns the underlying *cel.Ast.
+func (c *ClaimConditions) AST() *cel.Ast {
+	return c.ast
 }
 
 // UserInfo contains information about the user from the source OIDC provider.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -232,6 +232,10 @@ type ClaimConditions struct {
 
 // NewClaimConditions creates a ClaimConditions from the given CEL expression.
 func NewClaimConditions(expr string) (*ClaimConditions, error) {
+	if expr == "" {
+		return &ClaimConditions{}, nil
+	}
+
 	ast, err := celutils.ParseCEL(expr)
 	if err != nil {
 		return nil, err

--- a/openapi-v1.yaml
+++ b/openapi-v1.yaml
@@ -463,6 +463,12 @@ components:
           description: CEL expressions mapping token claims to other claims
           additionalProperties:
             type: string
+        claim_conditions:
+          type: string
+          description: |
+            A CEL expressions to restrict authentication to a subset of identities
+            whose claims must match the expressions. By default all identities
+            issued by the issuer are allowed to authenticate
 
     IssuerUpdate:
       properties:
@@ -482,6 +488,12 @@ components:
           description: CEL expressions mapping token claims to other claims
           additionalProperties:
             type: string
+        claim_conditions:
+          type: string
+          description: |
+            A CEL expressions to restrict authentication to a subset of identities
+            whose claims must match the expressions. By default all identities
+            issued by the issuer are allowed to authenticate
 
     Issuer:
       required:
@@ -490,6 +502,7 @@ components:
         - uri
         - jwks_uri
         - claim_mappings
+        - claim_conditions
       properties:
         id:
           x-go-name: ID
@@ -512,6 +525,12 @@ components:
           description: CEL expressions mapping token claims to other claims
           additionalProperties:
             type: string
+        claim_conditions:
+          type: string
+          description: |
+            A CEL expressions to restrict authentication to a subset of identities
+            whose claims must match the expressions. By default all identities
+            issued by the issuer are allowed to authenticate
 
     CreateOAuthClient:
       required:

--- a/pkg/api/v1/types.gen.go
+++ b/pkg/api/v1/types.gen.go
@@ -40,6 +40,11 @@ type CreateGroup struct {
 
 // CreateIssuer defines model for CreateIssuer.
 type CreateIssuer struct {
+	// ClaimConditions A CEL expressions to restrict authentication to a subset of identities
+	// whose claims must match the expressions. By default all identities
+	// issued by the issuer are allowed to authenticate
+	ClaimConditions *string `json:"claim_conditions,omitempty"`
+
 	// ClaimMappings CEL expressions mapping token claims to other claims
 	ClaimMappings *map[string]string `json:"claim_mappings,omitempty"`
 
@@ -85,6 +90,11 @@ type Group struct {
 
 // Issuer defines model for Issuer.
 type Issuer struct {
+	// ClaimConditions A CEL expressions to restrict authentication to a subset of identities
+	// whose claims must match the expressions. By default all identities
+	// issued by the issuer are allowed to authenticate
+	ClaimConditions string `json:"claim_conditions"`
+
 	// ClaimMappings CEL expressions mapping token claims to other claims
 	ClaimMappings map[string]string `json:"claim_mappings"`
 
@@ -103,6 +113,11 @@ type Issuer struct {
 
 // IssuerUpdate defines model for IssuerUpdate.
 type IssuerUpdate struct {
+	// ClaimConditions A CEL expressions to restrict authentication to a subset of identities
+	// whose claims must match the expressions. By default all identities
+	// issued by the issuer are allowed to authenticate
+	ClaimConditions *string `json:"claim_conditions,omitempty"`
+
 	// ClaimMappings CEL expressions mapping token claims to other claims
 	ClaimMappings *map[string]string `json:"claim_mappings,omitempty"`
 
@@ -311,47 +326,49 @@ type CreateIssuerJSONRequestBody = CreateIssuer
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xbX1PjOBL/KirfPdxVmRh2n443Frao7DE3HBlqtmaWmlJsJdGMLXklGchR/u5XLcn/",
-	"ZccJgQtz80SwpVb3r/+ouyU/eSFPUs4IU9I7ffJSLHBCFBH6v6XgWTq9gJ8RkaGgqaKceacejRBfIIz0",
-	"AM/3KDxMsVp5vsdwQrzTcq7vCfJnRgWJvFMlMuJ7MlyRBANRtU5hqFSCsqXne49HS35kHy5p9Di5FmRB",
-	"H0mk6ZRvj2iScqEMv2oFg/mEsoXAii8FTldETEKeBI8BEPHy3M61nF1aznLfo1JmRAxIyJAZ4paRRgco",
-	"3rSQKfc9/sAGxUOCSJ6JkCA90i1lQeTwRH1vOct9L8VLcp4JyUVXWLUiKNTvkOII/hNEZrGS8K8gKhOs",
-	"kPzPjIh1JbqZ5Y2VNBTR/HFyXkzaWkwaEaaoWh/hlAaUKSIYjgNN1crOcUqPQh6RJWFH5FEJfKTwUjur",
-	"Yb3kObegXNGEqi4mMTyWBRgpZ5KgkMcxCWGA7MFDz3LBAcwuifDGMmkIAY8ym38loRoyUjvEbZ3V/MOz",
-	"z1nJG7wpcNZA6CB0XgIOj0LOFGF6MZymMQ0xvAm+SvO6EiYVPCVCUVIFaf2LKpLoH38VZOGden8JquAe",
-	"mOky0AuDnqz0WAi8th5EGS6YGSJxXY00chWofy6YaVC7K9fiRo85zGqqGteMD5Ru6eR+Ea33B9UXGjXR",
-	"eq5tsCyO23g6dxy5X5i1IPtBGgGpAux3JJkTsVfAe2Fubckv6ZiJFmvv2h/PwICBGMj3aSE1af1KDXuy",
-	"FkNcM2uyjb0Yi8m0xkcys/SLhbKCnWdjVhDKfe/9WaZW5zElTO0FslCTGg9Zbf0Xw63g6dm4aWbRuSWX",
-	"+96t3JOl7San72VyG/sEdrsot9AyJJ+NlSGj8ymzOjB3FkW1gC67ODRDYnOF6YUEwpAgWneHbBlHUZFD",
-	"l7XfLpF0dDjsD2t3ud+W8MZmWF1JZRaGRDrEhEQR0aacD0QQkJREyM5bZHEMTFqe55zHBHdNv1gFWDsX",
-	"BCtisq0OOw0enjq6rf2PFlC11OBuopwXeXCXCDzfNLvFvyZVMW8DrCPqYJp8SXCaUmbSehxFFBbG8XVj",
-	"ZIfZJpPnv14h8pgKIiUUHciSRIp/IwzpZbTVcbUiwv7vdbzD974+fJNfMkG7MPz28Z8zdHsz7YjeNDgY",
-	"BqN64TxDqyzB7EgQHOF5TJrolj2CjrxOpm5vpq2pE/QukwolWIUr/fgP2H7+8IzM6B7HYKUMURbyBBD6",
-	"7eMHuUEmLY9LwYarGmqVxuv7Q0ftOIsoYaELHfsG6kmskFpRicw2gELMEHBApOqPFY6taBc1mCXHW/kF",
-	"iYkiOwSNs/gBryWC2DHZLiq8Qjww2XY7mBex3D2t1UG62By9nxN1bF/qyzCnesw2bL8v+1SDvLfTvKjo",
-	"JVi2tJ7eTOgbxrAnMG2v7h8RdmSErZtTK8z6beupDO02jbAiP3bat2wHzfJum+3zUmCmtKzFGLnVXumK",
-	"AaZ4+mlybAsopL38ZaL+RW174gu7oEtHkoSCqB5ma7zOzLhNG3nd10p0wamuG/Vdc61a3VQ2vmvFl9/S",
-	"Wuxun4Pl6FdQeUVVBtIl7vkeecRJGhPv9OTYbzfMdb9cRLDXnADA5FENHmAUK8FA4LtB38Mf//2PT7+v",
-	"VvPff5GfZierT+wmDunJMb6M/3P1Mf7WZwKvcn7R0p5B9s4RZEw0PPTSyTYkuhySBNO4S/ZXeFxszFCv",
-	"j03eKleG9fbjyNSV1lYLmV1pkFnXoWM/pv8CRDfILrP5EE/2MKXUywiu7BR34AAIzKJ3WpmULXh3/RkJ",
-	"M0HVGn3QO+WMiHsaEvS32YfZ39E7zPCSJBCyzq6niEqEmf4FPCbwEnaQ2YcZCjlb0GUmdJCRumigSrts",
-	"zwJN0p7v3RMhDUvHk+PJic6iU8JwSr1T7+fJ8eRn3UVSK63YADzw/iSwzbjgyfyYXuRGRCh84BfYreZp",
-	"GulADs/ru5jfuBHw2a2dsLbDOE7oiqX3dkCX53et07Sfjo+3agcOte1aVaGj+TYrm0KoNgxsKUmwPt40",
-	"NLQ51LuYoHZ9EPq5niqYRHBpNsamQi6J+j/XRqNjvYsqLomSCHxbJHp9hOc8U5VmqrRj0q+e3C89ypxM",
-	"Bk/2fkvLn9qJkTUDe24yX6PpBSzjcrtLu8+0VOwCpxoSFNds3o5LoELQAutLc9Zbc4JWegwa3ADhJVGa",
-	"zC9rbdkHiKE9d9+nCRskJ24oU6hwHBWRzq1aePqIs3ht0h7MokYSFWKG5gRlel7URb6erD0PeN0k/IVH",
-	"671hXuetlX9CxMsPU92Vino9ZSAeBUl12tPvTvXjjuomX593XVGpGidJOyva3zi0dpFr5Ghzw6nPeV0E",
-	"ynGB+8KDw/0aYA1EsJRLB+ZnUQT6NET0Odow4O2Tu0NzrDZ/r+xcfcd+O7mbQzdD+s0c6r0haYzN8cc2",
-	"bmWn/dD0K2m6VNM4Zx4RZIOn8vrhYCJ4QxJ+T2pmthA8qZuHWhEqeowEptZAeMngW12mPPh8sg/SMeq0",
-	"N3KCJxqNqIenRc95sPgyhy6GMkQRS/Ol740fUC0sNtbCFp0HqkzvfUnvCbNWX+hram9LDdXEZow71x/W",
-	"ypKoN66SotO2iypMJVXqodyWXNiX9YMr3d/NJUwN8Vr4738vbJzVvfJG+By1lwVFoXm3znsCZFDeeht2",
-	"x1u5S/5Cq69VDqw0aN02dHiSBga8yJq4tuFBXPUFAxk82U9q8qB2gbO3AQhjG/2obTHm5WcyBwax+zqs",
-	"A2mOq86mRtxcDmkA3umouksxc9Gp1pq1/dLyuEfvSZp+Nxnr3pLa1JLVfCqOUsHvqaSc6UUaK2cseq1P",
-	"r14sNHaBeeX4+Ow+cY9djGsKd/y6+ijH2YO5olIhHMf2OxdtfLjX6sr2y3fk+u3vn5rK2ITP6MZLqVVb",
-	"amlfG+vnuzU1S8hf1NXeWlOzUsSYAq3jT7VvQ5z7JBiMuf9X+2rju3CUzgc2rrMBI3TPxtjI6q2XuMx9",
-	"m6SeF/taqKeWGRD7LvaxerL9NlL82u41MsXXyWvwBH9s86ovAYVEeEytXd1OcViAWeeN1Njmy529HtUB",
-	"ybpOTLU0oJExKYQs9sf5WhcjiEbu7AFW68sg/pdKPMispPGxcTcvcYDu0mtePuvUBIV6JOIMVRtW4yqV",
-	"1OIOTWx+HldObySpm2gUNXtxkVWOWbg0pPrHu9LL7/L/BgAA//+ed8WcTkQAAA==",
+	"H4sIAAAAAAAC/+xb3XPbuBH/VzBsH9oZWrTvnuo3x77x6Jo0qRVPbpJ4MhC5kpCQAA8Abase/u8dfPAb",
+	"pChZduXUT5ZJYLH72w/sLsAHL2RJyihQKbzTBy/FHCcggev/lpxl6fRC/YxAhJykkjDqnXokQmyBMNID",
+	"PN8j6mGK5crzPYoT8E7Lub7H4c+McIi8U8kz8D0RriDBiqhcp2qokJzQped790dLdmQfLkl0P/nAYUHu",
+	"IdJ0yrdHJEkZl4ZfuVKD2YTQBceSLTlOV8AnIUuC+0AR8fLczrWcXVrOct8jQmTABySkyAxxy0iiAxRv",
+	"WsiU+x67o4PiIQ6CZTwEpEe6pSyIHJ6o7y1nue+leAnnGReMd4WVK0ChfockQ+o/DiKLpVD/cpAZp4Xk",
+	"f2bA15XoZpY3VtKQR/P7yXkxaWsxSQRUErk+wikJCJXAKY4DTdXKznBKjkIWwRLoEdxLjo8kXmpnNayX",
+	"POcWlLckIbKLSaweiwKMlFEBKGRxDKEaIHrw0LNccChml8C9sUwaQopHkc2/QyiHjNQOcVtnNf/w7HNW",
+	"8qbeFDhrIHQQOi8BV49CRiVQvRhO05iEWL0JvgvzuhIm5SwFLglUQVr/IhIS/eOvHBbeqfeXoArugZku",
+	"Ar2w0pOVHnOO19aDCMUFM0MkPlQjjVwF6l8KZhrUbsq1mNFjrmY1VY1rxqeUbunkfhGt9wfVNxI10Xqs",
+	"bdAsjtt4OnccsV+YtSD7QRopUgXY7yCZA98r4L0wt7bkp3TMRIu1d+2PZ2DAQAzk+7SQmrR+pYY9WYsh",
+	"rpk12cZejMVkWuMjmVn6yUJZwc6jMSsI5b73/iyTq/OYAJV7gSzUpMZDVlv/yXAreHo0bppZdG7J5b53",
+	"LfZkabvJ6XuZ2MY+FbtdlFtoGZKPxsqQ0fmUWV0xdxZFtYAuujg0Q2JzhemFUIRVgmjdXWXLOIqKHLqs",
+	"/XaJpKPDYX9Yu8n9toRXNsPqSiqyMAThEFMliog05bwDDkpSiJCdt8jiWDFpeZ4zFgPumn6ximLtnAOW",
+	"YLKtDjsNHh46uq39jxaqaqnB3UQ5L/LgLhH1fNPsFv+aVMW8DbCOqINJ8i1kNCKmWOisfobOf3uL4D7l",
+	"IIQaYiottWwoEc7kShU6xlu1WakcX4DU4dIUQQTEV3q3YqouUesJlGRCogTLcKVFqlGfoDdrFMECZ7FE",
+	"OI4bNHT4jdB8rWeZYIyw0nAcszvQ9lzjCL5SF8pG5gSnKaGmlMGRER/HHxrodKY2oWkDY0kiyX4ALUSV",
+	"DDG5Am7/9zoRwfe+3/0Q3zJOuuD//umfM3R9Ne2I0XQyNUyN6jWhM7TKEkyPOOAIz2NoWlTZF+nI62Tq",
+	"+mramjpB75oK/aq23K+ekRnd4lh5JkWEhixRCP3+6aPYIJOWx2XUhqsaapWV1/fEjqnjLCJAQxc69o2q",
+	"obFEckUEMlsfCjFFigMQsj8+OrbfXdRglhzv2RcQg4QdAuVZfIfXAql4OdkuEj5DDDQVRnsDK/Yv97RW",
+	"1+xi8471mEhre3HfhjnVY7Zh+33ZmxvkvZ3aRkX/xLKl9fQa7g843A/bTU8w3t7EX3eVkbtK3YVaW0vH",
+	"evyuC1X+dp1GWMKr170mWS/LHZrdjG0yp0uOqdSyFmPEVmmSKxSaXsEvk2PbL0A62D3Nhn9Ry0zYwi7o",
+	"0pGAkIPsYbbG68yM25TD1UNOia4KJB8a7YzmWrU2QXnOU+s1+C2txe7TImU5+hXKBERV8tkl7vke3OMk",
+	"jcE7PTn22+dD+niIRyrNOFEAw70cPK8rVlIDFd8N+h7+9O9/fP5jtZr/8UZ8np2sPtOrOCQnx/gy/s/b",
+	"T/GPPhN4luO6lvYMsjeOIGN2gEPvFNj+W5dDSDCJu2R/U4+L/CQT7ig27Mpqvf04MnFVNNVCZiceZNZ1",
+	"xt6P6b8UohtkF9l8iCd7dljqZQRXdoo7cCgIzKI3WpmELlh3/RmEGSdyjT7qnXIG/JaEgP42+zj7O3qH",
+	"KV5CokLW2YcpIgJhqn8pHhP1Uu0gs48zFDK6IMuM6yAjdL1IpHbZngWapD3fuwUuDEvHk+PJiS6gUqA4",
+	"Jd6p9+vkePKrbprKlVZsoDzw9iSwvefgwfyYXuRGRFXzql/KbjVP00gHcvW8vov5jQswX9zaCWs7jONA",
+	"ulh6b+fReX7TOjz+5fh4q+73UJe61RBw9JpnZQ8U1YYpW0oSrE/zDQ1tDvWmvVK7Pvf/Uk8VTPK7NBtj",
+	"UyGXIP/PtdE4oNlFFZcgBVK+zROT+OM5y2SlmSrtmPSrJ/dLjzIH8cGDvc7V8qd2YmTNwB4TztdoeqGW",
+	"cbndpd1nWip2gVMNCYpbZS/HJVAhaIH1pbnaUHOCVnqsNLgBwkuQmsybtbbsA8TQXjPZpwkbJCduKFNV",
+	"4TgqIp1btfD0EaPx2qQ9mEaNJCrEFM0BZXpe1EW+nqw9DnjdH37DovXeMK/z1so/VcTLD1PdlYp6PWUg",
+	"HgVJdbjZ7071073q4mqfd70lQjYOTndWtL9xaO3e4sjR5kJfn/O6CJTjAvf9Hof7NcAaiGApEw7Mz6JI",
+	"6dMQMa2nQcDbB9WH5lht/p7ZufpOuXdyN4duhvSbOdR7BWmMzcnXNm5lp71q+pk0XappnDOPCLLBQ3nb",
+	"djARvIKE3ULNzBacJXXzkCsgvMdI1NQaCE8ZfKu7wwefT/ZBOkad9gJa8ECiEfXwtOg5DxZf5uzJNvol",
+	"Q5bmU38mcUC1MN9YC1t07og0vfcluQVqrb7Q19ReDhyqic0Yd64/rJUlyBeukqLTtosqTCVV6qHcllzY",
+	"l/WDK93fzSVMDfFc+O9/L2ycTz7zRvgYtZcFRaF5t857AmRQXvIcdsdrsUv+QqqPsw6sNGhdrnV4kgZG",
+	"eZE1cW3Dg7jquyUieLBfkOVB7b5ybwNQjW30o7bFmJVfhR0YxO7b3w6kGa46mxpxcy+oAXino+ouxcwd",
+	"t1pr1vZLy+MevSdp+t1krHtBblNLVvMpGUo5uyVCXzxYQXPljEbP9aXhk4XGLjDPHB8f3SfusYtxTeGO",
+	"X1ffoDl7MG+JMFdGzDhtfLjX6sr2y0/k+u3P/ZrK2ITP6MZLqVVbamlfG+vnuzU1S8if1NVeWlOzUsSY",
+	"Aq3jT7VPoZz7pDIYc/Wz9pHST+Eone/JXGcDRuiejbGR1VsvcZn7Nkk9K/a1UE8tMyD6U+xj9WT7ZaT4",
+	"td1rZIqvk9fgQf2xzau+BFQlwmNq7ep2isMCzDovpMY2H6rt9ahOkazrxFRLAxoZk0KIYn+cr3Uxgkjk",
+	"zh7Uan0ZxP9SiQeZlTS+re/mJQ7QXXrNy2edmqBQj0CMomrDalylElrcoYnNr0HL6Y0kdRONomYvLrKK",
+	"MQuXhlT/Vl14+U3+3wAAAP//sWso8z1HAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file


### PR DESCRIPTION
Adds a condition CEL to issuers, this allows the API to evaluate a subject's claim upon token exchange to restrict only a subset of users can obtain token.

Conditions are useful in use cases like trusting a public CI issuer (e.g., https://token.actions.githubusercontent.com, https://agent.buildkite.com) but restrict exchange to only certain orgs.